### PR TITLE
feat: add minidraco/three/single single-threaded entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ new MiniDRACOLoader({ workers: false }) // decode on the main thread
 new MiniDRACOLoader({ workerLimit: 8 }) // pool size (default 4)
 ```
 
+If you _only_ ever decode on the main thread, import from `minidraco/three/single` instead — same
+API, but with no worker code so the bundler never emits the worker chunk.
+
 Or decode a raw bitstream without Three.js:
 
 ```ts

--- a/library/package.json
+++ b/library/package.json
@@ -15,6 +15,10 @@
     "./three": {
       "types": "./dist/three.d.ts",
       "import": "./dist/three.js"
+    },
+    "./three/single": {
+      "types": "./dist/three-single.d.ts",
+      "import": "./dist/three-single.js"
     }
   },
   "scripts": {

--- a/library/src/three/index.ts
+++ b/library/src/three/index.ts
@@ -4,57 +4,21 @@
 // to GLTFLoader.setDRACOLoader() with no cast, on any three version.
 //
 // By default decoding runs in a pool of module workers (parallel across
-// primitives, main thread stays free), with a transparent synchronous fallback
+// primitives, main thread stays free), with a transparent main-thread fallback
 // when workers are unavailable (SSR, worker bundling unsupported). Pass
-// `{ workers: false }` (or setWorkers(false) / setWorkerLimit(0)) to decode
-// synchronously on the main thread instead.
-import {
-  BufferAttribute,
-  BufferGeometry,
-  Color,
-  ColorManagement,
-  FileLoader,
-  LinearSRGBColorSpace,
-  Loader,
-  SRGBColorSpace,
-} from 'three'
+// `{ workers: false }` (or setWorkers(false) / setWorkerLimit(0)) to decode on
+// the main thread instead. Apps that ONLY ever decode single-threaded should
+// import `minidraco/three/single`, which drops the worker code entirely so the
+// bundler never emits the worker chunk.
+import { BufferAttribute, BufferGeometry } from 'three'
 
-// Import shared decoder symbols via the public entry (not deep decoder
-// paths): it keeps the dts build free of hashed shared-type chunks — three.d.ts
-// simply imports from index.d.ts.
-import { decodeDracoMesh, GeometryAttributeType } from '../index'
+import { MiniDRACOLoader as MiniDRACOLoaderBase } from './loader-base'
 
 import type { LoadingManager } from 'three'
 
-import type { Mesh, PointAttribute } from '../index'
+import type { MiniDRACOLoaderOptions, TaskConfig } from './loader-base'
 
-export type AttributeIDs = Record<string, number | string>
-export type AttributeTypes = Record<string, string>
-
-export interface MiniDRACOLoaderOptions {
-  // three.js LoadingManager, as with any loader.
-  manager?: LoadingManager
-  // false → decode synchronously on the main thread (no worker pool).
-  // Default true. Equivalent to workerLimit: 0 / setWorkers(false).
-  workers?: boolean
-  // Worker pool size when workers are enabled (default 4).
-  workerLimit?: number
-  // See the syncByteThreshold field (default 0 = always use the pool).
-  syncByteThreshold?: number
-}
-
-// LoadingManager instances expose itemStart(); an options bag does not. Lets
-// the constructor keep the three-compatible `new Loader(manager)` form while
-// also accepting `new MiniDRACOLoader({ workers: false })`.
-const isLoadingManager = (value: unknown): value is LoadingManager =>
-  typeof (value as { itemStart?: unknown } | null | undefined)?.itemStart === 'function'
-
-interface TaskConfig {
-  attributeIDs: AttributeIDs
-  attributeTypes: AttributeTypes
-  useUniqueIDs: boolean
-  vertexColorSpace: string
-}
+export type { AttributeIDs, AttributeTypes, MiniDRACOLoaderOptions } from './loader-base'
 
 interface RawAttribute {
   name: string
@@ -80,47 +44,7 @@ interface QueuedTask {
   reject: (error: unknown) => void
 }
 
-type TypedArrayConstructor =
-  | Float32ArrayConstructor
-  | Int8ArrayConstructor
-  | Int16ArrayConstructor
-  | Int32ArrayConstructor
-  | Uint8ArrayConstructor
-  | Uint16ArrayConstructor
-  | Uint32ArrayConstructor
-
-const _taskCache = new WeakMap<ArrayBuffer, { key: string; promise: Promise<BufferGeometry> }>()
-
-const _attributeTypeMap: Record<string, number> = {
-  POSITION: GeometryAttributeType.POSITION,
-  NORMAL: GeometryAttributeType.NORMAL,
-  COLOR: GeometryAttributeType.COLOR,
-  TEX_COORD: GeometryAttributeType.TEX_COORD,
-  GENERIC: GeometryAttributeType.GENERIC,
-}
-
-const _typedArrayMap: Record<string, TypedArrayConstructor> = {
-  Float32Array,
-  Int8Array,
-  Int16Array,
-  Int32Array,
-  Uint8Array,
-  Uint16Array,
-  Uint32Array,
-}
-
-class MiniDRACOLoader extends Loader<BufferGeometry> {
-  defaultAttributeIDs: AttributeIDs
-  defaultAttributeTypes: AttributeTypes
-  workerLimit: number
-  // Opt-in (0 = disabled): buffers at or below this size decode synchronously
-  // on the main thread instead of paying the ~0.5 ms worker message roundtrip.
-  // Worth enabling (e.g. 4096) when the main thread is otherwise idle during
-  // loads — in a full GLTFLoader parse the main thread is already busy
-  // building geometries, and measurements show the pool wins there even for
-  // tiny primitives.
-  syncByteThreshold: number
-
+class MiniDRACOLoader extends MiniDRACOLoaderBase {
   _workers: WorkerEntry[]
   _taskId: number
   _tasks: Map<number, { resolve: (raw: RawGeometry) => void; reject: (error: unknown) => void; entry: WorkerEntry }>
@@ -136,29 +60,8 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
   // origin (created lazily, revoked on dispose).
   _workerBlobUrl: string | null
 
-  // Accepts either a LoadingManager (three-compatible form) or an options bag.
   constructor(managerOrOptions?: LoadingManager | MiniDRACOLoaderOptions) {
-    const options: MiniDRACOLoaderOptions = isLoadingManager(managerOrOptions)
-      ? { manager: managerOrOptions }
-      : (managerOrOptions ?? {})
-    super(options.manager)
-
-    this.defaultAttributeIDs = {
-      position: 'POSITION',
-      normal: 'NORMAL',
-      color: 'COLOR',
-      uv: 'TEX_COORD',
-    }
-
-    this.defaultAttributeTypes = {
-      position: 'Float32Array',
-      normal: 'Float32Array',
-      color: 'Float32Array',
-      uv: 'Float32Array',
-    }
-
-    this.workerLimit = options.workers === false ? 0 : (options.workerLimit ?? 4)
-    this.syncByteThreshold = options.syncByteThreshold ?? 0
+    super(managerOrOptions)
     this._workers = []
     this._taskId = 0
     this._tasks = new Map()
@@ -178,27 +81,8 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
     return this
   }
 
-  // No-ops kept for API compatibility with THREE.DRACOLoader — minidraco has
-  // no external decoder files to configure. The params are `unknown` (not
-  // `string`/`object`) so the signatures stay assignable to THREE.DRACOLoader
-  // across three versions, whose setDecoderPath has grown to accept a
-  // `string | DecoderPaths` — letting `new MiniDRACOLoader()` be passed to
-  // GLTFLoader.setDRACOLoader() with no cast.
-  setDecoderPath(_path?: unknown): this {
-    return this
-  }
-
-  setDecoderConfig(_config?: unknown): this {
-    return this
-  }
-
-  setWorkerLimit(limit: number): this {
-    this.workerLimit = limit
-    return this
-  }
-
-  // Toggle the worker pool on/off. false decodes synchronously on the main
-  // thread; true enables the pool, keeping the current size or falling back to
+  // Toggle the worker pool on/off. false decodes on the main thread; true
+  // enables the pool, keeping the current size or falling back to
   // the default 4 if it was disabled. For a specific pool size use
   // setWorkerLimit(n).
   setWorkers(enabled: boolean): this {
@@ -206,7 +90,7 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
     return this
   }
 
-  preload(): this {
+  override preload(): this {
     // Spawn the whole pool, not just one worker: each fresh worker runs a
     // short JIT warmup at startup (see worker.ts), so spawning them all here
     // lets that overlap the model download instead of the first decode burst.
@@ -218,7 +102,7 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
     return this
   }
 
-  dispose(): this {
+  override dispose(): this {
     for (const entry of this._workers) entry.worker.terminate()
     this._workers = []
     // Settle everything still outstanding so no caller promise hangs after
@@ -242,75 +126,7 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
     return this
   }
 
-  override load(
-    url: string,
-    onLoad: (geometry: BufferGeometry) => void,
-    onProgress?: (event: ProgressEvent) => void,
-    onError?: (err: unknown) => void,
-  ): void {
-    const loader = new FileLoader(this.manager)
-
-    loader.setPath(this.path)
-    loader.setResponseType('arraybuffer')
-    loader.setRequestHeader(this.requestHeader)
-    loader.setWithCredentials(this.withCredentials)
-
-    loader.load(
-      url,
-      buffer => {
-        this.parse(buffer as ArrayBuffer, onLoad, onError)
-      },
-      onProgress,
-      onError,
-    )
-  }
-
-  parse(
-    buffer: ArrayBuffer,
-    onLoad: (geometry: BufferGeometry) => void,
-    onError: (err: unknown) => void = () => {},
-  ): void {
-    this.decodeDracoFile(buffer, onLoad, null, null, SRGBColorSpace, onError).catch(onError)
-  }
-
-  decodeDracoFile(
-    buffer: ArrayBuffer,
-    callback?: (geometry: BufferGeometry) => void,
-    attributeIDs?: AttributeIDs | null,
-    attributeTypes?: AttributeTypes | null,
-    vertexColorSpace: string = LinearSRGBColorSpace,
-    onError: (err: unknown) => void = () => {},
-  ): Promise<BufferGeometry | void> {
-    const taskConfig: TaskConfig = {
-      attributeIDs: attributeIDs || this.defaultAttributeIDs,
-      attributeTypes: attributeTypes || this.defaultAttributeTypes,
-      useUniqueIDs: !!attributeIDs,
-      vertexColorSpace,
-    }
-
-    return this.decodeGeometry(buffer, taskConfig).then(callback).catch(onError)
-  }
-
-  decodeGeometry(buffer: ArrayBuffer, taskConfig: TaskConfig): Promise<BufferGeometry> {
-    const taskKey = JSON.stringify(taskConfig)
-
-    if (_taskCache.has(buffer)) {
-      const cachedTask = _taskCache.get(buffer)!
-      if (cachedTask.key === taskKey) {
-        return cachedTask.promise
-      }
-      // Same buffer, different settings: fall through and re-decode. (The input
-      // is copied to the worker, never transferred, so it's still intact.)
-    }
-
-    const geometryPending = this._runTask(buffer, taskConfig)
-
-    _taskCache.set(buffer, { key: taskKey, promise: geometryPending })
-
-    return geometryPending
-  }
-
-  async _runTask(buffer: ArrayBuffer, taskConfig: TaskConfig): Promise<BufferGeometry> {
+  override async _runTask(buffer: ArrayBuffer, taskConfig: TaskConfig): Promise<BufferGeometry> {
     if (this._workersAvailable()) {
       if (buffer.byteLength > this.syncByteThreshold) {
         try {
@@ -318,14 +134,14 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
           return this._buildGeometryFromRaw(raw, taskConfig)
         } catch (error) {
           // Decode errors (malformed data) carry `isDecodeError`; anything else
-          // is worker infrastructure failing — fall back to the sync path.
+          // is worker infrastructure failing — fall back to the main thread.
           if ((error as { isDecodeError?: boolean })?.isDecodeError) throw error
           this._workersBroken = true
         }
       } else {
         // Tiny buffer: decode on the main thread, but yield one microtask
         // first so a caller looping over many primitives finishes posting the
-        // large ones to the workers before we start doing sync work.
+        // large ones to the workers before we start doing main-thread work.
         await Promise.resolve()
       }
     }
@@ -357,7 +173,7 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
         // that imports the CDN URL instead (the import is a CORS request, so
         // the CDN must send Access-Control-Allow-Origin — as it already must
         // for fonts/models). If that import fails, the worker's error event
-        // trips the sync fallback below.
+        // trips the main-thread fallback below.
         try {
           if (this._workerBlobUrl === null) {
             const bootstrap = `import ${JSON.stringify(String(workerUrl))};`
@@ -434,7 +250,7 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
     }
     if (this._workersBroken || this._workers.length === 0) {
       // The pool broke (possibly between queueing and this flush) or spawning
-      // failed; _runTask falls back to the synchronous path per task.
+      // failed; _runTask falls back to the main-thread path per task.
       const error = new Error('MiniDRACOLoader: worker unavailable')
       for (const task of batch) task.reject(error)
       return
@@ -493,87 +309,6 @@ class MiniDRACOLoader extends Loader<BufferGeometry> {
     geometry.setIndex(new BufferAttribute(raw.indices, 1))
     return geometry
   }
-
-  // Synchronous main-thread decode (worker fallback and DracoJs-style reuse).
-  _decodeBuffer(buffer: ArrayBuffer, taskConfig: TaskConfig): BufferGeometry {
-    const mesh = decodeDracoMesh(new Uint8Array(buffer))
-    return this._buildGeometry(mesh, taskConfig)
-  }
-
-  _buildGeometry(dracoGeometry: Mesh, taskConfig: TaskConfig): BufferGeometry {
-    const attributeIDs = taskConfig.attributeIDs
-    const attributeTypes = taskConfig.attributeTypes
-
-    const geometry = new BufferGeometry()
-    const numPoints = dracoGeometry.numPoints()
-
-    for (const attributeName in attributeIDs) {
-      const OutputTypedArray = _typedArrayMap[attributeTypes[attributeName]]
-      if (!OutputTypedArray) continue
-
-      let attribute: PointAttribute | null
-
-      if (taskConfig.useUniqueIDs) {
-        const uniqueId = attributeIDs[attributeName] as number
-        attribute = dracoGeometry.getAttributeByUniqueId(uniqueId)
-      } else {
-        const typeEnum = _attributeTypeMap[attributeIDs[attributeName] as string]
-        if (typeEnum === undefined) continue
-        attribute = dracoGeometry.getNamedAttribute(typeEnum)
-      }
-
-      if (!attribute) continue
-
-      const itemSize = attribute.numComponents
-      const array = attribute.extractTo(OutputTypedArray, numPoints)
-
-      const bufferAttribute = new BufferAttribute(array, itemSize)
-
-      if (attributeName === 'color') {
-        this._assignVertexColorSpace(bufferAttribute, taskConfig.vertexColorSpace)
-        bufferAttribute.normalized = !(array instanceof Float32Array)
-      }
-
-      geometry.setAttribute(attributeName, bufferAttribute)
-    }
-
-    const numFaces = dracoGeometry.numFaces()
-    const index = new Uint32Array(numFaces * 3)
-    index.set(dracoGeometry.faces_.subarray(0, numFaces * 3))
-
-    geometry.setIndex(new BufferAttribute(index, 1))
-
-    return geometry
-  }
-
-  _assignVertexColorSpace(attribute: BufferAttribute, inputColorSpace: string): void {
-    if (inputColorSpace !== SRGBColorSpace) return
-
-    const _color = new Color()
-
-    for (let i = 0, il = attribute.count; i < il; i++) {
-      _color.fromBufferAttribute(attribute, i)
-      ColorManagement.colorSpaceToWorking(_color, SRGBColorSpace)
-      attribute.setXYZ(i, _color.r, _color.g, _color.b)
-    }
-  }
 }
 
 export { MiniDRACOLoader, MiniDRACOLoader as DRACOLoader }
-
-// --- Compile-time guard: MiniDRACOLoader must stay assignable to a
-// THREE.DRACOLoader-shaped type so it can be passed to
-// GLTFLoader.setDRACOLoader() with no cast on any three version. Newer three
-// types setDecoderPath as `string | DecoderPaths`, so the no-op setters must
-// accept a widened param (see setDecoderPath/setDecoderConfig above). This is
-// purely type-level — it emits no runtime code. If the surface regresses,
-// `_LoaderAssignabilityGuard` resolves to a non-`true` type and errors here.
-type _DracoLoaderShape = {
-  setDecoderPath(path: string | Record<string, string>): unknown
-  setDecoderConfig(config: object): unknown
-  setWorkerLimit(limit: number): unknown
-  preload(): unknown
-  dispose(): unknown
-}
-type _Expect<T extends true> = T
-type _LoaderAssignabilityGuard = _Expect<MiniDRACOLoader extends _DracoLoaderShape ? true : false>

--- a/library/src/three/loader-base.ts
+++ b/library/src/three/loader-base.ts
@@ -1,0 +1,303 @@
+// Single-threaded core of the DRACOLoader drop-in: everything except the
+// worker pool. It decodes on the main thread and has NO reference to the
+// worker (no `new Worker(new URL('./worker.js', ...))`), so importing it via
+// `minidraco/three/single` never makes a bundler emit the worker chunk. The
+// worker-pool loader in ./index.ts extends this and adds the pool.
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  ColorManagement,
+  FileLoader,
+  LinearSRGBColorSpace,
+  Loader,
+  SRGBColorSpace,
+} from 'three'
+
+// Import shared decoder symbols via the public entry (not deep decoder
+// paths): it keeps the dts build free of hashed shared-type chunks.
+import { decodeDracoMesh, GeometryAttributeType } from '../index'
+
+import type { LoadingManager } from 'three'
+
+import type { Mesh, PointAttribute } from '../index'
+
+export type AttributeIDs = Record<string, number | string>
+export type AttributeTypes = Record<string, string>
+
+export interface MiniDRACOLoaderOptions {
+  // three.js LoadingManager, as with any loader.
+  manager?: LoadingManager
+  // false → decode on the main thread (no worker pool). Default true. Ignored
+  // by the `minidraco/three/single` entry, which is always single-threaded.
+  workers?: boolean
+  // Worker pool size when workers are enabled (default 4).
+  workerLimit?: number
+  // See the syncByteThreshold field on the worker-pool loader.
+  syncByteThreshold?: number
+}
+
+export interface TaskConfig {
+  attributeIDs: AttributeIDs
+  attributeTypes: AttributeTypes
+  useUniqueIDs: boolean
+  vertexColorSpace: string
+}
+
+type TypedArrayConstructor =
+  | Float32ArrayConstructor
+  | Int8ArrayConstructor
+  | Int16ArrayConstructor
+  | Int32ArrayConstructor
+  | Uint8ArrayConstructor
+  | Uint16ArrayConstructor
+  | Uint32ArrayConstructor
+
+// Shared across every loader instance (and both entry points), keyed by the
+// input ArrayBuffer — mirrors THREE.DRACOLoader's per-buffer decode cache.
+const _taskCache = new WeakMap<ArrayBuffer, { key: string; promise: Promise<BufferGeometry> }>()
+
+const _attributeTypeMap: Record<string, number> = {
+  POSITION: GeometryAttributeType.POSITION,
+  NORMAL: GeometryAttributeType.NORMAL,
+  COLOR: GeometryAttributeType.COLOR,
+  TEX_COORD: GeometryAttributeType.TEX_COORD,
+  GENERIC: GeometryAttributeType.GENERIC,
+}
+
+const _typedArrayMap: Record<string, TypedArrayConstructor> = {
+  Float32Array,
+  Int8Array,
+  Int16Array,
+  Int32Array,
+  Uint8Array,
+  Uint16Array,
+  Uint32Array,
+}
+
+// LoadingManager instances expose itemStart(); an options bag does not. Lets
+// the constructor keep the three-compatible `new Loader(manager)` form while
+// also accepting `new MiniDRACOLoader({ workers: false })`.
+const isLoadingManager = (value: unknown): value is LoadingManager =>
+  typeof (value as { itemStart?: unknown } | null | undefined)?.itemStart === 'function'
+
+class MiniDRACOLoader extends Loader<BufferGeometry> {
+  defaultAttributeIDs: AttributeIDs
+  defaultAttributeTypes: AttributeTypes
+  workerLimit: number
+  // Opt-in (0 = disabled): with the worker pool, buffers at or below this size
+  // decode on the main thread instead of paying the ~0.5 ms message roundtrip.
+  // Ignored by the single-threaded loader (already main-thread).
+  syncByteThreshold: number
+
+  // Accepts either a LoadingManager (three-compatible form) or an options bag.
+  constructor(managerOrOptions?: LoadingManager | MiniDRACOLoaderOptions) {
+    const options: MiniDRACOLoaderOptions = isLoadingManager(managerOrOptions)
+      ? { manager: managerOrOptions }
+      : (managerOrOptions ?? {})
+    super(options.manager)
+
+    this.defaultAttributeIDs = {
+      position: 'POSITION',
+      normal: 'NORMAL',
+      color: 'COLOR',
+      uv: 'TEX_COORD',
+    }
+
+    this.defaultAttributeTypes = {
+      position: 'Float32Array',
+      normal: 'Float32Array',
+      color: 'Float32Array',
+      uv: 'Float32Array',
+    }
+
+    this.workerLimit = options.workers === false ? 0 : (options.workerLimit ?? 4)
+    this.syncByteThreshold = options.syncByteThreshold ?? 0
+  }
+
+  // No-ops kept for API compatibility with THREE.DRACOLoader — minidraco has
+  // no external decoder files to configure. The params are `unknown` (not
+  // `string`/`object`) so the signatures stay assignable to THREE.DRACOLoader
+  // across three versions, whose setDecoderPath has grown to accept a
+  // `string | DecoderPaths` — letting the loader be passed to
+  // GLTFLoader.setDRACOLoader() with no cast.
+  setDecoderPath(_path?: unknown): this {
+    return this
+  }
+
+  setDecoderConfig(_config?: unknown): this {
+    return this
+  }
+
+  setWorkerLimit(limit: number): this {
+    this.workerLimit = limit
+    return this
+  }
+
+  // The worker-pool loader overrides these; on the single-threaded loader they
+  // are no-ops.
+  preload(): this {
+    return this
+  }
+
+  dispose(): this {
+    return this
+  }
+
+  override load(
+    url: string,
+    onLoad: (geometry: BufferGeometry) => void,
+    onProgress?: (event: ProgressEvent) => void,
+    onError?: (err: unknown) => void,
+  ): void {
+    const loader = new FileLoader(this.manager)
+
+    loader.setPath(this.path)
+    loader.setResponseType('arraybuffer')
+    loader.setRequestHeader(this.requestHeader)
+    loader.setWithCredentials(this.withCredentials)
+
+    loader.load(
+      url,
+      buffer => {
+        this.parse(buffer as ArrayBuffer, onLoad, onError)
+      },
+      onProgress,
+      onError,
+    )
+  }
+
+  parse(
+    buffer: ArrayBuffer,
+    onLoad: (geometry: BufferGeometry) => void,
+    onError: (err: unknown) => void = () => {},
+  ): void {
+    this.decodeDracoFile(buffer, onLoad, null, null, SRGBColorSpace, onError).catch(onError)
+  }
+
+  decodeDracoFile(
+    buffer: ArrayBuffer,
+    callback?: (geometry: BufferGeometry) => void,
+    attributeIDs?: AttributeIDs | null,
+    attributeTypes?: AttributeTypes | null,
+    vertexColorSpace: string = LinearSRGBColorSpace,
+    onError: (err: unknown) => void = () => {},
+  ): Promise<BufferGeometry | void> {
+    const taskConfig: TaskConfig = {
+      attributeIDs: attributeIDs || this.defaultAttributeIDs,
+      attributeTypes: attributeTypes || this.defaultAttributeTypes,
+      useUniqueIDs: !!attributeIDs,
+      vertexColorSpace,
+    }
+
+    return this.decodeGeometry(buffer, taskConfig).then(callback).catch(onError)
+  }
+
+  decodeGeometry(buffer: ArrayBuffer, taskConfig: TaskConfig): Promise<BufferGeometry> {
+    const taskKey = JSON.stringify(taskConfig)
+
+    if (_taskCache.has(buffer)) {
+      const cachedTask = _taskCache.get(buffer)!
+      if (cachedTask.key === taskKey) {
+        return cachedTask.promise
+      }
+      // Same buffer, different settings: fall through and re-decode. (The input
+      // is copied to the worker, never transferred, so it's still intact.)
+    }
+
+    const geometryPending = this._runTask(buffer, taskConfig)
+
+    _taskCache.set(buffer, { key: taskKey, promise: geometryPending })
+
+    return geometryPending
+  }
+
+  // Single-threaded loader: always decode on the main thread. The worker-pool
+  // loader overrides this to route through the pool with a main-thread fallback.
+  async _runTask(buffer: ArrayBuffer, taskConfig: TaskConfig): Promise<BufferGeometry> {
+    return this._decodeBuffer(buffer, taskConfig)
+  }
+
+  // Main-thread decode (also the worker fallback and the DracoJs-style
+  // subclass reuse point).
+  _decodeBuffer(buffer: ArrayBuffer, taskConfig: TaskConfig): BufferGeometry {
+    const mesh = decodeDracoMesh(new Uint8Array(buffer))
+    return this._buildGeometry(mesh, taskConfig)
+  }
+
+  _buildGeometry(dracoGeometry: Mesh, taskConfig: TaskConfig): BufferGeometry {
+    const attributeIDs = taskConfig.attributeIDs
+    const attributeTypes = taskConfig.attributeTypes
+
+    const geometry = new BufferGeometry()
+    const numPoints = dracoGeometry.numPoints()
+
+    for (const attributeName in attributeIDs) {
+      const OutputTypedArray = _typedArrayMap[attributeTypes[attributeName]]
+      if (!OutputTypedArray) continue
+
+      let attribute: PointAttribute | null
+
+      if (taskConfig.useUniqueIDs) {
+        const uniqueId = attributeIDs[attributeName] as number
+        attribute = dracoGeometry.getAttributeByUniqueId(uniqueId)
+      } else {
+        const typeEnum = _attributeTypeMap[attributeIDs[attributeName] as string]
+        if (typeEnum === undefined) continue
+        attribute = dracoGeometry.getNamedAttribute(typeEnum)
+      }
+
+      if (!attribute) continue
+
+      const itemSize = attribute.numComponents
+      const array = attribute.extractTo(OutputTypedArray, numPoints)
+
+      const bufferAttribute = new BufferAttribute(array, itemSize)
+
+      if (attributeName === 'color') {
+        this._assignVertexColorSpace(bufferAttribute, taskConfig.vertexColorSpace)
+        bufferAttribute.normalized = !(array instanceof Float32Array)
+      }
+
+      geometry.setAttribute(attributeName, bufferAttribute)
+    }
+
+    const numFaces = dracoGeometry.numFaces()
+    const index = new Uint32Array(numFaces * 3)
+    index.set(dracoGeometry.faces_.subarray(0, numFaces * 3))
+
+    geometry.setIndex(new BufferAttribute(index, 1))
+
+    return geometry
+  }
+
+  _assignVertexColorSpace(attribute: BufferAttribute, inputColorSpace: string): void {
+    if (inputColorSpace !== SRGBColorSpace) return
+
+    const _color = new Color()
+
+    for (let i = 0, il = attribute.count; i < il; i++) {
+      _color.fromBufferAttribute(attribute, i)
+      ColorManagement.colorSpaceToWorking(_color, SRGBColorSpace)
+      attribute.setXYZ(i, _color.r, _color.g, _color.b)
+    }
+  }
+}
+
+export { MiniDRACOLoader, MiniDRACOLoader as DRACOLoader }
+
+// --- Compile-time guard: the loader must stay assignable to a
+// THREE.DRACOLoader-shaped type so it can be passed to
+// GLTFLoader.setDRACOLoader() with no cast on any three version. Newer three
+// types setDecoderPath as `string | DecoderPaths`, so the no-op setters must
+// accept a widened param. Purely type-level — emits no runtime code. Covers
+// the worker-pool subclass too, which inherits this surface.
+type _DracoLoaderShape = {
+  setDecoderPath(path: string | Record<string, string>): unknown
+  setDecoderConfig(config: object): unknown
+  setWorkerLimit(limit: number): unknown
+  preload(): unknown
+  dispose(): unknown
+}
+type _Expect<T extends true> = T
+type _LoaderAssignabilityGuard = _Expect<MiniDRACOLoader extends _DracoLoaderShape ? true : false>

--- a/library/src/three/single.ts
+++ b/library/src/three/single.ts
@@ -1,0 +1,9 @@
+// minidraco/three/single — single-threaded DRACOLoader drop-in.
+//
+// Same decoder and API as `minidraco/three`, but with no worker pool: it never
+// references the worker chunk, so a bundler won't emit a second copy of the
+// decoder for apps that only ever decode on the main thread. Reach for this
+// when you always want `workers: false`; if you need the pool (even
+// conditionally, or a mix of loaders), import from `minidraco/three` instead.
+export { DRACOLoader, MiniDRACOLoader } from './loader-base'
+export type { AttributeIDs, AttributeTypes, MiniDRACOLoaderOptions } from './loader-base'

--- a/library/tsup.config.js
+++ b/library/tsup.config.js
@@ -16,8 +16,17 @@ export default defineConfig([
     splitting: false,
   },
   {
-    // `minidraco/three` — the DRACOLoader drop-in built on top of the core.
+    // `minidraco/three` — the DRACOLoader drop-in (worker pool) built on the core.
     entry: { three: 'src/three/index.ts' },
+    format: ['esm'],
+    dts: true,
+    splitting: false,
+  },
+  {
+    // `minidraco/three/single` — single-threaded-only drop-in. Built on its own
+    // (self-contained dts) and with no reference to the worker, so bundlers
+    // never emit the worker chunk for consumers that import it.
+    entry: { 'three-single': 'src/three/single.ts' },
     format: ['esm'],
     dts: true,
     splitting: false,


### PR DESCRIPTION
## What

Adds a `minidraco/three/single` entry point — a single-threaded-only `DRACOLoader` drop-in that carries no worker code.

## Why

`workers: false` avoids *running* the pool, but bundlers still emit the `worker.js` chunk — a second full copy of the decoder (~22 KB brotli) — because `three/index.ts` statically contains `new Worker(new URL('./worker.js', import.meta.url))`. Apps that only ever decode on the main thread were shipping that dead chunk.

## How

- **`three/loader-base.ts`** (new) — the single-threaded core: decode, geometry building, task cache, DRACOLoader-compat API, and the type-assignability guard. Zero worker references.
- **`three/single.ts`** (new) — `minidraco/three/single`, re-exports the base as `MiniDRACOLoader` / `DRACOLoader`.
- **`three/index.ts`** — `MiniDRACOLoader` now extends the base and adds the worker pool. The only file containing `new Worker(...)`.
- Added the `./three/single` package export, a self-contained tsup build entry, and one README line.

`minidraco/three` is unchanged — the `workers` boolean stays for mixed use (some loaders pooled, some not).

## Verified

- `dist/three-single.js`: **0** `new Worker`/`worker.js` references; `dist/three.js`: 2 (unchanged).
- Typecheck clean, **49 tests pass**, example still builds against `minidraco/three`.
- Runtime smoke test: the single-threaded loader has no `_getWorker` and decodes correctly on the main thread.

## Note

New public export → warrants a **0.3.0** bump at publish time (left out here to match the separate `chore: publish` commit pattern). A natural first consumer is any app doing `new MiniDRACOLoader({ workers: false })`, which can switch its import to `minidraco/three/single` to drop the worker chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)