### PR TITLE
perf: round 2 — traversal-map sharing, DFS visited-flag fold, zigzag fusion

### DIFF
--- a/BENCH.browser.json
+++ b/BENCH.browser.json
@@ -11,9 +11,9 @@
         "primitives": 7,
         "faces": 2544,
         "medianMs": {
-          "minidraco": 2.8,
+          "minidraco": 2.5,
           "draco.js": 3.5,
-          "draco3d (wasm)": 1.9
+          "draco3d (wasm)": 2
         }
       },
       {
@@ -21,9 +21,9 @@
         "primitives": 488,
         "faces": 220879,
         "medianMs": {
-          "minidraco": 77.3,
-          "draco.js": 95.4,
-          "draco3d (wasm)": 74.1
+          "minidraco": 75.1,
+          "draco.js": 90.8,
+          "draco3d (wasm)": 73.4
         }
       },
       {
@@ -32,8 +32,8 @@
         "faces": 24448,
         "medianMs": {
           "minidraco": 6,
-          "draco.js": 7.6,
-          "draco3d (wasm)": 6.8
+          "draco.js": 8,
+          "draco3d (wasm)": 7.1
         }
       },
       {
@@ -41,9 +41,9 @@
         "primitives": 71,
         "faces": 141802,
         "medianMs": {
-          "minidraco": 117.7,
-          "draco.js": 131.6,
-          "draco3d (wasm)": 109.9
+          "minidraco": 110.7,
+          "draco.js": 121.7,
+          "draco3d (wasm)": 114.6
         }
       },
       {
@@ -51,9 +51,9 @@
         "primitives": 3,
         "faces": 13388,
         "medianMs": {
-          "minidraco": 6.9,
+          "minidraco": 6.7,
           "draco.js": 8,
-          "draco3d (wasm)": 7.4
+          "draco3d (wasm)": 7.3
         }
       },
       {
@@ -62,8 +62,8 @@
         "faces": 32158,
         "medianMs": {
           "minidraco": 8.1,
-          "draco.js": 10.4,
-          "draco3d (wasm)": 8.7
+          "draco.js": 9.8,
+          "draco3d (wasm)": 8.6
         }
       },
       {
@@ -71,7 +71,7 @@
         "primitives": 1,
         "faces": 4212,
         "medianMs": {
-          "minidraco": 1.3,
+          "minidraco": 1.4,
           "draco.js": 1.8,
           "draco3d (wasm)": 1.6
         }
@@ -81,9 +81,9 @@
         "primitives": 51,
         "faces": 358788,
         "medianMs": {
-          "minidraco": 103.7,
-          "draco.js": 116.1,
-          "draco3d (wasm)": 114.5
+          "minidraco": 96.9,
+          "draco.js": 114.9,
+          "draco3d (wasm)": 112.4
         }
       },
       {
@@ -91,9 +91,9 @@
         "primitives": 12,
         "faces": 10956,
         "medianMs": {
-          "minidraco": 5.6,
-          "draco.js": 5.8,
-          "draco3d (wasm)": 4.4
+          "minidraco": 3.8,
+          "draco.js": 4.7,
+          "draco3d (wasm)": 4
         }
       },
       {
@@ -101,9 +101,9 @@
         "primitives": 3,
         "faces": 21696,
         "medianMs": {
-          "minidraco": 5.6,
-          "draco.js": 6.4,
-          "draco3d (wasm)": 5.2
+          "minidraco": 5.1,
+          "draco.js": 6.2,
+          "draco3d (wasm)": 5.1
         }
       },
       {
@@ -111,9 +111,9 @@
         "primitives": 43,
         "faces": 51601,
         "medianMs": {
-          "minidraco": 16.5,
-          "draco.js": 20.2,
-          "draco3d (wasm)": 17.8
+          "minidraco": 14.7,
+          "draco.js": 18.4,
+          "draco3d (wasm)": 17.1
         }
       },
       {
@@ -121,8 +121,8 @@
         "primitives": 4,
         "faces": 10457,
         "medianMs": {
-          "minidraco": 4.4,
-          "draco.js": 5.2,
+          "minidraco": 4.2,
+          "draco.js": 5,
           "draco3d (wasm)": 4.5
         }
       },
@@ -131,9 +131,9 @@
         "primitives": 1,
         "faces": 320352,
         "medianMs": {
-          "minidraco": 183.8,
-          "draco.js": 222.6,
-          "draco3d (wasm)": 213.1
+          "minidraco": 207,
+          "draco.js": 231.9,
+          "draco3d (wasm)": 196.8
         }
       },
       {
@@ -141,9 +141,9 @@
         "primitives": 2,
         "faces": 22280,
         "medianMs": {
-          "minidraco": 6.6,
-          "draco.js": 8.5,
-          "draco3d (wasm)": 6.1
+          "minidraco": 6.5,
+          "draco.js": 7.9,
+          "draco3d (wasm)": 5.7
         }
       },
       {
@@ -151,9 +151,9 @@
         "primitives": 24,
         "faces": 120336,
         "medianMs": {
-          "minidraco": 57,
-          "draco.js": 60.7,
-          "draco3d (wasm)": 54.6
+          "minidraco": 57.3,
+          "draco.js": 65.2,
+          "draco3d (wasm)": 59.4
         }
       },
       {
@@ -161,9 +161,9 @@
         "primitives": 5,
         "faces": 295600,
         "medianMs": {
-          "minidraco": 105.6,
-          "draco.js": 122.8,
-          "draco3d (wasm)": 103.4
+          "minidraco": 116.9,
+          "draco.js": 134.9,
+          "draco3d (wasm)": 115.9
         }
       },
       {
@@ -171,9 +171,9 @@
         "primitives": 1,
         "faces": 69451,
         "medianMs": {
-          "minidraco": 13.7,
-          "draco.js": 7.8,
-          "draco3d (wasm)": 5.7
+          "minidraco": 15.3,
+          "draco.js": 8.8,
+          "draco3d (wasm)": 6.2
         }
       },
       {
@@ -182,7 +182,7 @@
         "faces": 1744,
         "medianMs": {
           "minidraco": 0.1,
-          "draco.js": 3.8,
+          "draco.js": 3.3,
           "draco3d (wasm)": 0.2
         }
       },
@@ -191,9 +191,9 @@
         "primitives": 1,
         "faces": 4212,
         "medianMs": {
-          "minidraco": 1.2,
-          "draco.js": 1.5,
-          "draco3d (wasm)": 1.4
+          "minidraco": 1.4,
+          "draco.js": 1.7,
+          "draco3d (wasm)": 1.5
         }
       }
     ]
@@ -208,129 +208,129 @@
       {
         "file": "manablade-characters.glb",
         "medianMs": {
-          "minidraco": 6,
-          "draco.js": 10.8,
+          "minidraco": 4.8,
+          "draco.js": 10,
           "draco3d (wasm)": 3.3
         }
       },
       {
         "file": "manablade-static.glb",
         "medianMs": {
-          "minidraco": 48.9,
-          "draco.js": 108.8,
-          "draco3d (wasm)": 35.5
+          "minidraco": 47.1,
+          "draco.js": 115.8,
+          "draco3d (wasm)": 36.4
         }
       },
       {
         "file": "IridescentDishWithOlives.glb",
         "medianMs": {
-          "minidraco": 80.4,
-          "draco.js": 81.7,
-          "draco3d (wasm)": 73
+          "minidraco": 87.5,
+          "draco.js": 82.5,
+          "draco3d (wasm)": 77.6
         }
       },
       {
         "file": "LittlestTokyo.glb",
         "medianMs": {
-          "minidraco": 118.5,
-          "draco.js": 234.1,
-          "draco3d (wasm)": 141.1
+          "minidraco": 113.3,
+          "draco.js": 237.8,
+          "draco3d (wasm)": 113.5
         }
       },
       {
         "file": "ShaderBall2.glb",
         "medianMs": {
-          "minidraco": 21.1,
-          "draco.js": 30.1,
-          "draco3d (wasm)": 22.6
+          "minidraco": 19.3,
+          "draco.js": 27.9,
+          "draco3d (wasm)": 21.1
         }
       },
       {
         "file": "bath_day.glb",
         "medianMs": {
-          "minidraco": 51.3,
-          "draco.js": 65.5,
-          "draco3d (wasm)": 54.1
+          "minidraco": 56.8,
+          "draco.js": 65.3,
+          "draco3d (wasm)": 53.4
         }
       },
       {
         "file": "duck.glb",
         "medianMs": {
-          "minidraco": 2.6,
-          "draco.js": 3.9,
-          "draco3d (wasm)": 2.8
+          "minidraco": 2.5,
+          "draco.js": 4.3,
+          "draco3d (wasm)": 2.7
         }
       },
       {
         "file": "ferrari.glb",
         "medianMs": {
           "minidraco": 40.7,
-          "draco.js": 137.1,
-          "draco3d (wasm)": 40.6
+          "draco.js": 126.3,
+          "draco3d (wasm)": 42
         }
       },
       {
         "file": "forest_house.glb",
         "medianMs": {
-          "minidraco": 36.6,
-          "draco.js": 45,
-          "draco3d (wasm)": 37.1
+          "minidraco": 35.9,
+          "draco.js": 45.1,
+          "draco3d (wasm)": 34.9
         }
       },
       {
         "file": "gears.glb",
         "medianMs": {
-          "minidraco": 3.5,
-          "draco.js": 6.9,
-          "draco3d (wasm)": 3
+          "minidraco": 3.6,
+          "draco.js": 7.6,
+          "draco3d (wasm)": 3.2
         }
       },
       {
         "file": "kira.glb",
         "medianMs": {
-          "minidraco": 292.9,
-          "draco.js": 281.1,
-          "draco3d (wasm)": 266.7
+          "minidraco": 317.3,
+          "draco.js": 314.7,
+          "draco3d (wasm)": 290.8
         }
       },
       {
         "file": "minimalistic_modern_bedroom.glb",
         "medianMs": {
-          "minidraco": 36.4,
-          "draco.js": 41.9,
-          "draco3d (wasm)": 35
+          "minidraco": 38,
+          "draco.js": 46.6,
+          "draco3d (wasm)": 39.3
         }
       },
       {
         "file": "nemetona.glb",
         "medianMs": {
-          "minidraco": 248.4,
-          "draco.js": 260.1,
-          "draco3d (wasm)": 221.9
+          "minidraco": 249.7,
+          "draco.js": 279.8,
+          "draco3d (wasm)": 210.8
         }
       },
       {
         "file": "pool.glb",
         "medianMs": {
-          "minidraco": 111.8,
-          "draco.js": 77.9,
-          "draco3d (wasm)": 101.2
+          "minidraco": 72.7,
+          "draco.js": 67.5,
+          "draco3d (wasm)": 76.4
         }
       },
       {
         "file": "rolex.glb",
         "medianMs": {
-          "minidraco": 45.3,
-          "draco.js": 122.7,
-          "draco3d (wasm)": 40.8
+          "minidraco": 34.1,
+          "draco.js": 99.4,
+          "draco3d (wasm)": 33.7
         }
       },
       {
         "file": "venice_mask.glb",
         "medianMs": {
-          "minidraco": 138.3,
-          "draco.js": 258.6,
-          "draco3d (wasm)": 148.1
+          "minidraco": 103.4,
+          "draco.js": 233.7,
+          "draco3d (wasm)": 97.9
         }
       }
     ]

--- a/BENCH.json
+++ b/BENCH.json
@@ -12,9 +12,9 @@
       "points": 5050,
       "faces": 2544,
       "medianMs": {
-        "minidraco": 3.525,
-        "draco.js": 3.983,
-        "draco3d (wasm)": 2.878
+        "minidraco": 2.732,
+        "draco.js": 3.694,
+        "draco3d (wasm)": 2.717
       }
     },
     {
@@ -23,9 +23,9 @@
       "points": 291342,
       "faces": 220879,
       "medianMs": {
-        "minidraco": 65.111,
-        "draco.js": 74.51,
-        "draco3d (wasm)": 66.351
+        "minidraco": 67.523,
+        "draco.js": 76.944,
+        "draco3d (wasm)": 72.477
       }
     },
     {
@@ -34,9 +34,9 @@
       "points": 14864,
       "faces": 24448,
       "medianMs": {
-        "minidraco": 4.387,
-        "draco.js": 5.699,
-        "draco3d (wasm)": 6.609
+        "minidraco": 4.443,
+        "draco.js": 5.655,
+        "draco3d (wasm)": 7.218
       }
     },
     {
@@ -45,9 +45,9 @@
       "points": 193125,
       "faces": 141802,
       "medianMs": {
-        "minidraco": 90.243,
-        "draco.js": 100.754,
-        "draco3d (wasm)": 101.65
+        "minidraco": 95.388,
+        "draco.js": 105.499,
+        "draco3d (wasm)": 108.137
       }
     },
     {
@@ -56,9 +56,9 @@
       "points": 8377,
       "faces": 13388,
       "medianMs": {
-        "minidraco": 4.846,
-        "draco.js": 5.647,
-        "draco3d (wasm)": 6.661
+        "minidraco": 4.933,
+        "draco.js": 6.689,
+        "draco3d (wasm)": 7.237
       }
     },
     {
@@ -67,9 +67,9 @@
       "points": 21759,
       "faces": 32158,
       "medianMs": {
-        "minidraco": 6.414,
-        "draco.js": 7.635,
-        "draco3d (wasm)": 7.79
+        "minidraco": 6.262,
+        "draco.js": 7.903,
+        "draco3d (wasm)": 7.821
       }
     },
     {
@@ -78,9 +78,9 @@
       "points": 2277,
       "faces": 4212,
       "medianMs": {
-        "minidraco": 1.028,
-        "draco.js": 1.223,
-        "draco3d (wasm)": 1.52
+        "minidraco": 0.999,
+        "draco.js": 1.212,
+        "draco3d (wasm)": 1.524
       }
     },
     {
@@ -89,9 +89,9 @@
       "points": 337834,
       "faces": 358788,
       "medianMs": {
-        "minidraco": 71.946,
-        "draco.js": 83.677,
-        "draco3d (wasm)": 99.952
+        "minidraco": 70.715,
+        "draco.js": 87.753,
+        "draco3d (wasm)": 110.723
       }
     },
     {
@@ -100,9 +100,9 @@
       "points": 11924,
       "faces": 10956,
       "medianMs": {
-        "minidraco": 2.658,
-        "draco.js": 3.513,
-        "draco3d (wasm)": 3.473
+        "minidraco": 2.795,
+        "draco.js": 3.642,
+        "draco3d (wasm)": 3.803
       }
     },
     {
@@ -111,9 +111,9 @@
       "points": 23426,
       "faces": 21696,
       "medianMs": {
-        "minidraco": 3.378,
-        "draco.js": 4.04,
-        "draco3d (wasm)": 4.407
+        "minidraco": 3.505,
+        "draco.js": 4.582,
+        "draco3d (wasm)": 4.891
       }
     },
     {
@@ -122,9 +122,9 @@
       "points": 55486,
       "faces": 51601,
       "medianMs": {
-        "minidraco": 10.365,
-        "draco.js": 12.611,
-        "draco3d (wasm)": 15.129
+        "minidraco": 10.786,
+        "draco.js": 13.087,
+        "draco3d (wasm)": 15.948
       }
     },
     {
@@ -133,9 +133,9 @@
       "points": 13884,
       "faces": 10457,
       "medianMs": {
-        "minidraco": 3.25,
-        "draco.js": 3.438,
-        "draco3d (wasm)": 3.898
+        "minidraco": 3.198,
+        "draco.js": 3.795,
+        "draco3d (wasm)": 4.266
       }
     },
     {
@@ -144,9 +144,9 @@
       "points": 349197,
       "faces": 320352,
       "medianMs": {
-        "minidraco": 150.793,
-        "draco.js": 170.165,
-        "draco3d (wasm)": 179.066
+        "minidraco": 162.113,
+        "draco.js": 184.433,
+        "draco3d (wasm)": 196.992
       }
     },
     {
@@ -155,9 +155,9 @@
       "points": 13501,
       "faces": 22280,
       "medianMs": {
-        "minidraco": 6.161,
-        "draco.js": 7.781,
-        "draco3d (wasm)": 5.036
+        "minidraco": 7.037,
+        "draco.js": 8.247,
+        "draco3d (wasm)": 5.8
       }
     },
     {
@@ -166,9 +166,9 @@
       "points": 101560,
       "faces": 120336,
       "medianMs": {
-        "minidraco": 44.882,
-        "draco.js": 50.592,
-        "draco3d (wasm)": 51.589
+        "minidraco": 44.362,
+        "draco.js": 54.341,
+        "draco3d (wasm)": 58.452
       }
     },
     {
@@ -177,9 +177,9 @@
       "points": 173876,
       "faces": 295600,
       "medianMs": {
-        "minidraco": 84.051,
-        "draco.js": 99.63,
-        "draco3d (wasm)": 100.607
+        "minidraco": 89.045,
+        "draco.js": 108.903,
+        "draco3d (wasm)": 112.685
       }
     },
     {
@@ -188,9 +188,9 @@
       "points": 34834,
       "faces": 69451,
       "medianMs": {
-        "minidraco": 9.446,
-        "draco.js": 10.784,
-        "draco3d (wasm)": 5.49
+        "minidraco": 12.937,
+        "draco.js": 8.674,
+        "draco3d (wasm)": 5.897
       }
     },
     {
@@ -200,8 +200,8 @@
       "faces": 1744,
       "medianMs": {
         "minidraco": 0.086,
-        "draco.js": 4.184,
-        "draco3d (wasm)": 0.222
+        "draco.js": 3.558,
+        "draco3d (wasm)": 0.268
       }
     },
     {
@@ -210,9 +210,9 @@
       "points": 2277,
       "faces": 4212,
       "medianMs": {
-        "minidraco": 0.996,
-        "draco.js": 1.258,
-        "draco3d (wasm)": 1.355
+        "minidraco": 1.608,
+        "draco.js": 1.316,
+        "draco3d (wasm)": 1.631
       }
     }
   ]

--- a/BENCH.json
+++ b/BENCH.json
@@ -12,9 +12,9 @@
       "points": 5050,
       "faces": 2544,
       "medianMs": {
-        "minidraco": 2.732,
-        "draco.js": 3.694,
-        "draco3d (wasm)": 2.717
+        "minidraco": 2.681,
+        "draco.js": 3.356,
+        "draco3d (wasm)": 2.618
       }
     },
     {
@@ -23,9 +23,9 @@
       "points": 291342,
       "faces": 220879,
       "medianMs": {
-        "minidraco": 67.523,
-        "draco.js": 76.944,
-        "draco3d (wasm)": 72.477
+        "minidraco": 68.333,
+        "draco.js": 77.532,
+        "draco3d (wasm)": 73.371
       }
     },
     {
@@ -34,9 +34,9 @@
       "points": 14864,
       "faces": 24448,
       "medianMs": {
-        "minidraco": 4.443,
-        "draco.js": 5.655,
-        "draco3d (wasm)": 7.218
+        "minidraco": 4.438,
+        "draco.js": 6.233,
+        "draco3d (wasm)": 6.94
       }
     },
     {
@@ -45,9 +45,9 @@
       "points": 193125,
       "faces": 141802,
       "medianMs": {
-        "minidraco": 95.388,
-        "draco.js": 105.499,
-        "draco3d (wasm)": 108.137
+        "minidraco": 96.565,
+        "draco.js": 109.359,
+        "draco3d (wasm)": 108.902
       }
     },
     {
@@ -56,9 +56,9 @@
       "points": 8377,
       "faces": 13388,
       "medianMs": {
-        "minidraco": 4.933,
-        "draco.js": 6.689,
-        "draco3d (wasm)": 7.237
+        "minidraco": 5.898,
+        "draco.js": 6.555,
+        "draco3d (wasm)": 7.161
       }
     },
     {
@@ -67,9 +67,9 @@
       "points": 21759,
       "faces": 32158,
       "medianMs": {
-        "minidraco": 6.262,
-        "draco.js": 7.903,
-        "draco3d (wasm)": 7.821
+        "minidraco": 6.218,
+        "draco.js": 8.111,
+        "draco3d (wasm)": 7.877
       }
     },
     {
@@ -78,9 +78,9 @@
       "points": 2277,
       "faces": 4212,
       "medianMs": {
-        "minidraco": 0.999,
-        "draco.js": 1.212,
-        "draco3d (wasm)": 1.524
+        "minidraco": 0.997,
+        "draco.js": 1.215,
+        "draco3d (wasm)": 1.513
       }
     },
     {
@@ -89,9 +89,9 @@
       "points": 337834,
       "faces": 358788,
       "medianMs": {
-        "minidraco": 70.715,
-        "draco.js": 87.753,
-        "draco3d (wasm)": 110.723
+        "minidraco": 71.571,
+        "draco.js": 88.766,
+        "draco3d (wasm)": 112.06
       }
     },
     {
@@ -100,9 +100,9 @@
       "points": 11924,
       "faces": 10956,
       "medianMs": {
-        "minidraco": 2.795,
-        "draco.js": 3.642,
-        "draco3d (wasm)": 3.803
+        "minidraco": 3.34,
+        "draco.js": 3.946,
+        "draco3d (wasm)": 4.24
       }
     },
     {
@@ -111,9 +111,9 @@
       "points": 23426,
       "faces": 21696,
       "medianMs": {
-        "minidraco": 3.505,
-        "draco.js": 4.582,
-        "draco3d (wasm)": 4.891
+        "minidraco": 3.64,
+        "draco.js": 4.131,
+        "draco3d (wasm)": 4.672
       }
     },
     {
@@ -122,9 +122,9 @@
       "points": 55486,
       "faces": 51601,
       "medianMs": {
-        "minidraco": 10.786,
-        "draco.js": 13.087,
-        "draco3d (wasm)": 15.948
+        "minidraco": 10.765,
+        "draco.js": 13.382,
+        "draco3d (wasm)": 15.887
       }
     },
     {
@@ -133,9 +133,9 @@
       "points": 13884,
       "faces": 10457,
       "medianMs": {
-        "minidraco": 3.198,
-        "draco.js": 3.795,
-        "draco3d (wasm)": 4.266
+        "minidraco": 3.735,
+        "draco.js": 4.027,
+        "draco3d (wasm)": 4.502
       }
     },
     {
@@ -144,9 +144,9 @@
       "points": 349197,
       "faces": 320352,
       "medianMs": {
-        "minidraco": 162.113,
-        "draco.js": 184.433,
-        "draco3d (wasm)": 196.992
+        "minidraco": 164.316,
+        "draco.js": 193.415,
+        "draco3d (wasm)": 197.366
       }
     },
     {
@@ -155,9 +155,9 @@
       "points": 13501,
       "faces": 22280,
       "medianMs": {
-        "minidraco": 7.037,
-        "draco.js": 8.247,
-        "draco3d (wasm)": 5.8
+        "minidraco": 6.514,
+        "draco.js": 9.169,
+        "draco3d (wasm)": 6.252
       }
     },
     {
@@ -166,9 +166,9 @@
       "points": 101560,
       "faces": 120336,
       "medianMs": {
-        "minidraco": 44.362,
-        "draco.js": 54.341,
-        "draco3d (wasm)": 58.452
+        "minidraco": 47.444,
+        "draco.js": 55.25,
+        "draco3d (wasm)": 59.855
       }
     },
     {
@@ -177,9 +177,9 @@
       "points": 173876,
       "faces": 295600,
       "medianMs": {
-        "minidraco": 89.045,
-        "draco.js": 108.903,
-        "draco3d (wasm)": 112.685
+        "minidraco": 90.977,
+        "draco.js": 112.177,
+        "draco3d (wasm)": 113.877
       }
     },
     {
@@ -188,9 +188,9 @@
       "points": 34834,
       "faces": 69451,
       "medianMs": {
-        "minidraco": 12.937,
-        "draco.js": 8.674,
-        "draco3d (wasm)": 5.897
+        "minidraco": 10.583,
+        "draco.js": 12.068,
+        "draco3d (wasm)": 6.068
       }
     },
     {
@@ -199,9 +199,9 @@
       "points": 1856,
       "faces": 1744,
       "medianMs": {
-        "minidraco": 0.086,
-        "draco.js": 3.558,
-        "draco3d (wasm)": 0.268
+        "minidraco": 0.084,
+        "draco.js": 4.937,
+        "draco3d (wasm)": 0.327
       }
     },
     {
@@ -210,9 +210,9 @@
       "points": 2277,
       "faces": 4212,
       "medianMs": {
-        "minidraco": 1.608,
-        "draco.js": 1.316,
-        "draco3d (wasm)": 1.631
+        "minidraco": 1.442,
+        "draco.js": 1.517,
+        "draco3d (wasm)": 1.661
       }
     }
   ]

--- a/BENCH.md
+++ b/BENCH.md
@@ -18,25 +18,25 @@ Raw decode via `bun run bench`, median of 10 runs after 3 warmups.
 
 | file                              | prims |   faces | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
 | --------------------------------- | ----: | ------: | --------: | --------: | -------------: | --------------------- | ----------------- |
-| `manablade-characters.glb`        |     7 |   2,544 |   3.52 ms |   3.98 ms |        2.88 ms | 🟢 1.13x faster       | 🔴 1.22x slower   |
-| `manablade-static.glb`            |   488 | 220,879 |  65.11 ms |  74.51 ms |       66.35 ms | 🟢 1.14x faster       | ⚪ even           |
-| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   4.39 ms |   5.70 ms |        6.61 ms | 🟢 1.30x faster       | 🟢 1.51x faster   |
-| `LittlestTokyo.glb`               |    71 | 141,802 |  90.24 ms | 100.75 ms |      101.65 ms | 🟢 1.12x faster       | 🟢 1.13x faster   |
-| `ShaderBall2.glb`                 |     3 |  13,388 |   4.85 ms |   5.65 ms |        6.66 ms | 🟢 1.17x faster       | 🟢 1.37x faster   |
-| `bath_day.glb`                    |    22 |  32,158 |   6.41 ms |   7.63 ms |        7.79 ms | 🟢 1.19x faster       | 🟢 1.21x faster   |
-| `duck.glb`                        |     1 |   4,212 |   1.03 ms |   1.22 ms |        1.52 ms | 🟢 1.19x faster       | 🟢 1.48x faster   |
-| `ferrari.glb`                     |    51 | 358,788 |  71.95 ms |  83.68 ms |       99.95 ms | 🟢 1.16x faster       | 🟢 1.39x faster   |
-| `forest_house.glb`                |    12 |  10,956 |   2.66 ms |   3.51 ms |        3.47 ms | 🟢 1.32x faster       | 🟢 1.31x faster   |
-| `gears.glb`                       |     3 |  21,696 |   3.38 ms |   4.04 ms |        4.41 ms | 🟢 1.20x faster       | 🟢 1.30x faster   |
-| `kira.glb`                        |    43 |  51,601 |  10.37 ms |  12.61 ms |       15.13 ms | 🟢 1.22x faster       | 🟢 1.46x faster   |
-| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   3.25 ms |   3.44 ms |        3.90 ms | 🟢 1.06x faster       | 🟢 1.20x faster   |
-| `nemetona.glb`                    |     1 | 320,352 | 150.79 ms | 170.16 ms |      179.07 ms | 🟢 1.13x faster       | 🟢 1.19x faster   |
-| `pool.glb`                        |     2 |  22,280 |   6.16 ms |   7.78 ms |        5.04 ms | 🟢 1.26x faster       | 🔴 1.22x slower   |
-| `rolex.glb`                       |    24 | 120,336 |  44.88 ms |  50.59 ms |       51.59 ms | 🟢 1.13x faster       | 🟢 1.15x faster   |
-| `venice_mask.glb`                 |     5 | 295,600 |  84.05 ms |  99.63 ms |      100.61 ms | 🟢 1.19x faster       | 🟢 1.20x faster   |
-| `bunny.drc`                       |     1 |  69,451 |   9.45 ms |  10.78 ms |        5.49 ms | 🟢 1.14x faster       | 🔴 1.72x slower   |
-| `car.drc`                         |     1 |   1,744 |   0.09 ms |   4.18 ms |        0.22 ms | 🟢 48.65x faster      | 🟢 2.58x faster   |
-| `duck.drc`                        |     1 |   4,212 |   1.00 ms |   1.26 ms |        1.35 ms | 🟢 1.26x faster       | 🟢 1.36x faster   |
+| `manablade-characters.glb`        |     7 |   2,544 |   2.73 ms |   3.69 ms |        2.72 ms | 🟢 1.35x faster       | ⚪ even           |
+| `manablade-static.glb`            |   488 | 220,879 |  67.52 ms |  76.94 ms |       72.48 ms | 🟢 1.14x faster       | 🟢 1.07x faster   |
+| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   4.44 ms |   5.66 ms |        7.22 ms | 🟢 1.27x faster       | 🟢 1.62x faster   |
+| `LittlestTokyo.glb`               |    71 | 141,802 |  95.39 ms | 105.50 ms |      108.14 ms | 🟢 1.11x faster       | 🟢 1.13x faster   |
+| `ShaderBall2.glb`                 |     3 |  13,388 |   4.93 ms |   6.69 ms |        7.24 ms | 🟢 1.36x faster       | 🟢 1.47x faster   |
+| `bath_day.glb`                    |    22 |  32,158 |   6.26 ms |   7.90 ms |        7.82 ms | 🟢 1.26x faster       | 🟢 1.25x faster   |
+| `duck.glb`                        |     1 |   4,212 |   1.00 ms |   1.21 ms |        1.52 ms | 🟢 1.21x faster       | 🟢 1.53x faster   |
+| `ferrari.glb`                     |    51 | 358,788 |  70.72 ms |  87.75 ms |      110.72 ms | 🟢 1.24x faster       | 🟢 1.57x faster   |
+| `forest_house.glb`                |    12 |  10,956 |   2.79 ms |   3.64 ms |        3.80 ms | 🟢 1.30x faster       | 🟢 1.36x faster   |
+| `gears.glb`                       |     3 |  21,696 |   3.50 ms |   4.58 ms |        4.89 ms | 🟢 1.31x faster       | 🟢 1.40x faster   |
+| `kira.glb`                        |    43 |  51,601 |  10.79 ms |  13.09 ms |       15.95 ms | 🟢 1.21x faster       | 🟢 1.48x faster   |
+| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   3.20 ms |   3.79 ms |        4.27 ms | 🟢 1.19x faster       | 🟢 1.33x faster   |
+| `nemetona.glb`                    |     1 | 320,352 | 162.11 ms | 184.43 ms |      196.99 ms | 🟢 1.14x faster       | 🟢 1.22x faster   |
+| `pool.glb`                        |     2 |  22,280 |   7.04 ms |   8.25 ms |        5.80 ms | 🟢 1.17x faster       | 🔴 1.21x slower   |
+| `rolex.glb`                       |    24 | 120,336 |  44.36 ms |  54.34 ms |       58.45 ms | 🟢 1.22x faster       | 🟢 1.32x faster   |
+| `venice_mask.glb`                 |     5 | 295,600 |  89.05 ms | 108.90 ms |      112.69 ms | 🟢 1.22x faster       | 🟢 1.27x faster   |
+| `bunny.drc`                       |     1 |  69,451 |  12.94 ms |   8.67 ms |        5.90 ms | 🔴 1.49x slower       | 🔴 2.19x slower   |
+| `car.drc`                         |     1 |   1,744 |   0.09 ms |   3.56 ms |        0.27 ms | 🟢 41.37x faster      | 🟢 3.12x faster   |
+| `duck.drc`                        |     1 |   4,212 |   1.61 ms |   1.32 ms |        1.63 ms | 🔴 1.22x slower       | ⚪ even           |
 
 ## Browser — single-threaded raw decode (V8)
 

--- a/BENCH.md
+++ b/BENCH.md
@@ -18,25 +18,25 @@ Raw decode via `bun run bench`, median of 10 runs after 3 warmups.
 
 | file                              | prims |   faces | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
 | --------------------------------- | ----: | ------: | --------: | --------: | -------------: | --------------------- | ----------------- |
-| `manablade-characters.glb`        |     7 |   2,544 |   2.73 ms |   3.69 ms |        2.72 ms | 🟢 1.35x faster       | ⚪ even           |
-| `manablade-static.glb`            |   488 | 220,879 |  67.52 ms |  76.94 ms |       72.48 ms | 🟢 1.14x faster       | 🟢 1.07x faster   |
-| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   4.44 ms |   5.66 ms |        7.22 ms | 🟢 1.27x faster       | 🟢 1.62x faster   |
-| `LittlestTokyo.glb`               |    71 | 141,802 |  95.39 ms | 105.50 ms |      108.14 ms | 🟢 1.11x faster       | 🟢 1.13x faster   |
-| `ShaderBall2.glb`                 |     3 |  13,388 |   4.93 ms |   6.69 ms |        7.24 ms | 🟢 1.36x faster       | 🟢 1.47x faster   |
-| `bath_day.glb`                    |    22 |  32,158 |   6.26 ms |   7.90 ms |        7.82 ms | 🟢 1.26x faster       | 🟢 1.25x faster   |
-| `duck.glb`                        |     1 |   4,212 |   1.00 ms |   1.21 ms |        1.52 ms | 🟢 1.21x faster       | 🟢 1.53x faster   |
-| `ferrari.glb`                     |    51 | 358,788 |  70.72 ms |  87.75 ms |      110.72 ms | 🟢 1.24x faster       | 🟢 1.57x faster   |
-| `forest_house.glb`                |    12 |  10,956 |   2.79 ms |   3.64 ms |        3.80 ms | 🟢 1.30x faster       | 🟢 1.36x faster   |
-| `gears.glb`                       |     3 |  21,696 |   3.50 ms |   4.58 ms |        4.89 ms | 🟢 1.31x faster       | 🟢 1.40x faster   |
-| `kira.glb`                        |    43 |  51,601 |  10.79 ms |  13.09 ms |       15.95 ms | 🟢 1.21x faster       | 🟢 1.48x faster   |
-| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   3.20 ms |   3.79 ms |        4.27 ms | 🟢 1.19x faster       | 🟢 1.33x faster   |
-| `nemetona.glb`                    |     1 | 320,352 | 162.11 ms | 184.43 ms |      196.99 ms | 🟢 1.14x faster       | 🟢 1.22x faster   |
-| `pool.glb`                        |     2 |  22,280 |   7.04 ms |   8.25 ms |        5.80 ms | 🟢 1.17x faster       | 🔴 1.21x slower   |
-| `rolex.glb`                       |    24 | 120,336 |  44.36 ms |  54.34 ms |       58.45 ms | 🟢 1.22x faster       | 🟢 1.32x faster   |
-| `venice_mask.glb`                 |     5 | 295,600 |  89.05 ms | 108.90 ms |      112.69 ms | 🟢 1.22x faster       | 🟢 1.27x faster   |
-| `bunny.drc`                       |     1 |  69,451 |  12.94 ms |   8.67 ms |        5.90 ms | 🔴 1.49x slower       | 🔴 2.19x slower   |
-| `car.drc`                         |     1 |   1,744 |   0.09 ms |   3.56 ms |        0.27 ms | 🟢 41.37x faster      | 🟢 3.12x faster   |
-| `duck.drc`                        |     1 |   4,212 |   1.61 ms |   1.32 ms |        1.63 ms | 🔴 1.22x slower       | ⚪ even           |
+| `manablade-characters.glb`        |     7 |   2,544 |   2.68 ms |   3.36 ms |        2.62 ms | 🟢 1.25x faster       | ⚪ even           |
+| `manablade-static.glb`            |   488 | 220,879 |  68.33 ms |  77.53 ms |       73.37 ms | 🟢 1.13x faster       | 🟢 1.07x faster   |
+| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   4.44 ms |   6.23 ms |        6.94 ms | 🟢 1.40x faster       | 🟢 1.56x faster   |
+| `LittlestTokyo.glb`               |    71 | 141,802 |  96.56 ms | 109.36 ms |      108.90 ms | 🟢 1.13x faster       | 🟢 1.13x faster   |
+| `ShaderBall2.glb`                 |     3 |  13,388 |   5.90 ms |   6.55 ms |        7.16 ms | 🟢 1.11x faster       | 🟢 1.21x faster   |
+| `bath_day.glb`                    |    22 |  32,158 |   6.22 ms |   8.11 ms |        7.88 ms | 🟢 1.30x faster       | 🟢 1.27x faster   |
+| `duck.glb`                        |     1 |   4,212 |   1.00 ms |   1.22 ms |        1.51 ms | 🟢 1.22x faster       | 🟢 1.52x faster   |
+| `ferrari.glb`                     |    51 | 358,788 |  71.57 ms |  88.77 ms |      112.06 ms | 🟢 1.24x faster       | 🟢 1.57x faster   |
+| `forest_house.glb`                |    12 |  10,956 |   3.34 ms |   3.95 ms |        4.24 ms | 🟢 1.18x faster       | 🟢 1.27x faster   |
+| `gears.glb`                       |     3 |  21,696 |   3.64 ms |   4.13 ms |        4.67 ms | 🟢 1.13x faster       | 🟢 1.28x faster   |
+| `kira.glb`                        |    43 |  51,601 |  10.77 ms |  13.38 ms |       15.89 ms | 🟢 1.24x faster       | 🟢 1.48x faster   |
+| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   3.73 ms |   4.03 ms |        4.50 ms | 🟢 1.08x faster       | 🟢 1.21x faster   |
+| `nemetona.glb`                    |     1 | 320,352 | 164.32 ms | 193.41 ms |      197.37 ms | 🟢 1.18x faster       | 🟢 1.20x faster   |
+| `pool.glb`                        |     2 |  22,280 |   6.51 ms |   9.17 ms |        6.25 ms | 🟢 1.41x faster       | ⚪ even           |
+| `rolex.glb`                       |    24 | 120,336 |  47.44 ms |  55.25 ms |       59.85 ms | 🟢 1.16x faster       | 🟢 1.26x faster   |
+| `venice_mask.glb`                 |     5 | 295,600 |  90.98 ms | 112.18 ms |      113.88 ms | 🟢 1.23x faster       | 🟢 1.25x faster   |
+| `bunny.drc`                       |     1 |  69,451 |  10.58 ms |  12.07 ms |        6.07 ms | 🟢 1.14x faster       | 🔴 1.74x slower   |
+| `car.drc`                         |     1 |   1,744 |   0.08 ms |   4.94 ms |        0.33 ms | 🟢 58.77x faster      | 🟢 3.89x faster   |
+| `duck.drc`                        |     1 |   4,212 |   1.44 ms |   1.52 ms |        1.66 ms | 🟢 1.05x faster       | 🟢 1.15x faster   |
 
 ## Browser — single-threaded raw decode (V8)
 
@@ -48,25 +48,25 @@ overhead. Median of 10 runs after 3 warmups, saved from the example's `/bench` p
 
 | file                              | prims |   faces | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
 | --------------------------------- | ----: | ------: | --------: | --------: | -------------: | --------------------- | ----------------- |
-| `manablade-characters.glb`        |     7 |   2,544 |   2.80 ms |   3.50 ms |        1.90 ms | 🟢 1.25x faster       | 🔴 1.47x slower   |
-| `manablade-static.glb`            |   488 | 220,879 |  77.30 ms |  95.40 ms |       74.10 ms | 🟢 1.23x faster       | ⚪ even           |
-| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   6.00 ms |   7.60 ms |        6.80 ms | 🟢 1.27x faster       | 🟢 1.13x faster   |
-| `LittlestTokyo.glb`               |    71 | 141,802 | 117.70 ms | 131.60 ms |      109.90 ms | 🟢 1.12x faster       | 🔴 1.07x slower   |
-| `ShaderBall2.glb`                 |     3 |  13,388 |   6.90 ms |   8.00 ms |        7.40 ms | 🟢 1.16x faster       | 🟢 1.07x faster   |
-| `bath_day.glb`                    |    22 |  32,158 |   8.10 ms |  10.40 ms |        8.70 ms | 🟢 1.28x faster       | 🟢 1.07x faster   |
-| `duck.glb`                        |     1 |   4,212 |   1.30 ms |   1.80 ms |        1.60 ms | 🟢 1.38x faster       | 🟢 1.23x faster   |
-| `ferrari.glb`                     |    51 | 358,788 | 103.70 ms | 116.10 ms |      114.50 ms | 🟢 1.12x faster       | 🟢 1.10x faster   |
-| `forest_house.glb`                |    12 |  10,956 |   5.60 ms |   5.80 ms |        4.40 ms | ⚪ even               | 🔴 1.27x slower   |
-| `gears.glb`                       |     3 |  21,696 |   5.60 ms |   6.40 ms |        5.20 ms | 🟢 1.14x faster       | 🔴 1.08x slower   |
-| `kira.glb`                        |    43 |  51,601 |  16.50 ms |  20.20 ms |       17.80 ms | 🟢 1.22x faster       | 🟢 1.08x faster   |
-| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   4.40 ms |   5.20 ms |        4.50 ms | 🟢 1.18x faster       | ⚪ even           |
-| `nemetona.glb`                    |     1 | 320,352 | 183.80 ms | 222.60 ms |      213.10 ms | 🟢 1.21x faster       | 🟢 1.16x faster   |
-| `pool.glb`                        |     2 |  22,280 |   6.60 ms |   8.50 ms |        6.10 ms | 🟢 1.29x faster       | 🔴 1.08x slower   |
-| `rolex.glb`                       |    24 | 120,336 |  57.00 ms |  60.70 ms |       54.60 ms | 🟢 1.06x faster       | ⚪ even           |
-| `venice_mask.glb`                 |     5 | 295,600 | 105.60 ms | 122.80 ms |      103.40 ms | 🟢 1.16x faster       | ⚪ even           |
-| `bunny.drc`                       |     1 |  69,451 |  13.70 ms |   7.80 ms |        5.70 ms | 🔴 1.76x slower       | 🔴 2.40x slower   |
-| `car.drc`                         |     1 |   1,744 |   0.10 ms |   3.80 ms |        0.20 ms | 🟢 38.00x faster      | 🟢 2.00x faster   |
-| `duck.drc`                        |     1 |   4,212 |   1.20 ms |   1.50 ms |        1.40 ms | 🟢 1.25x faster       | 🟢 1.17x faster   |
+| `manablade-characters.glb`        |     7 |   2,544 |   2.50 ms |   3.50 ms |        2.00 ms | 🟢 1.40x faster       | 🔴 1.25x slower   |
+| `manablade-static.glb`            |   488 | 220,879 |  75.10 ms |  90.80 ms |       73.40 ms | 🟢 1.21x faster       | ⚪ even           |
+| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   6.00 ms |   8.00 ms |        7.10 ms | 🟢 1.33x faster       | 🟢 1.18x faster   |
+| `LittlestTokyo.glb`               |    71 | 141,802 | 110.70 ms | 121.70 ms |      114.60 ms | 🟢 1.10x faster       | ⚪ even           |
+| `ShaderBall2.glb`                 |     3 |  13,388 |   6.70 ms |   8.00 ms |        7.30 ms | 🟢 1.19x faster       | 🟢 1.09x faster   |
+| `bath_day.glb`                    |    22 |  32,158 |   8.10 ms |   9.80 ms |        8.60 ms | 🟢 1.21x faster       | 🟢 1.06x faster   |
+| `duck.glb`                        |     1 |   4,212 |   1.40 ms |   1.80 ms |        1.60 ms | 🟢 1.29x faster       | 🟢 1.14x faster   |
+| `ferrari.glb`                     |    51 | 358,788 |  96.90 ms | 114.90 ms |      112.40 ms | 🟢 1.19x faster       | 🟢 1.16x faster   |
+| `forest_house.glb`                |    12 |  10,956 |   3.80 ms |   4.70 ms |        4.00 ms | 🟢 1.24x faster       | 🟢 1.05x faster   |
+| `gears.glb`                       |     3 |  21,696 |   5.10 ms |   6.20 ms |        5.10 ms | 🟢 1.22x faster       | ⚪ even           |
+| `kira.glb`                        |    43 |  51,601 |  14.70 ms |  18.40 ms |       17.10 ms | 🟢 1.25x faster       | 🟢 1.16x faster   |
+| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   4.20 ms |   5.00 ms |        4.50 ms | 🟢 1.19x faster       | 🟢 1.07x faster   |
+| `nemetona.glb`                    |     1 | 320,352 | 207.00 ms | 231.90 ms |      196.80 ms | 🟢 1.12x faster       | 🔴 1.05x slower   |
+| `pool.glb`                        |     2 |  22,280 |   6.50 ms |   7.90 ms |        5.70 ms | 🟢 1.22x faster       | 🔴 1.14x slower   |
+| `rolex.glb`                       |    24 | 120,336 |  57.30 ms |  65.20 ms |       59.40 ms | 🟢 1.14x faster       | ⚪ even           |
+| `venice_mask.glb`                 |     5 | 295,600 | 116.90 ms | 134.90 ms |      115.90 ms | 🟢 1.15x faster       | ⚪ even           |
+| `bunny.drc`                       |     1 |  69,451 |  15.30 ms |   8.80 ms |        6.20 ms | 🔴 1.74x slower       | 🔴 2.47x slower   |
+| `car.drc`                         |     1 |   1,744 |   0.10 ms |   3.30 ms |        0.20 ms | 🟢 33.00x faster      | 🟢 2.00x faster   |
+| `duck.drc`                        |     1 |   4,212 |   1.40 ms |   1.70 ms |        1.50 ms | 🟢 1.21x faster       | 🟢 1.07x faster   |
 
 ## Browser — GLTFLoader wall clock (V8)
 
@@ -81,22 +81,22 @@ texture decode and scene-graph setup. Median of 5 runs after 1 warmup, GLBs only
 
 | file                              | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
 | --------------------------------- | --------: | --------: | -------------: | --------------------- | ----------------- |
-| `manablade-characters.glb`        |   6.00 ms |  10.80 ms |        3.30 ms | 🟢 1.80x faster       | 🔴 1.82x slower   |
-| `manablade-static.glb`            |  48.90 ms | 108.80 ms |       35.50 ms | 🟢 2.22x faster       | 🔴 1.38x slower   |
-| `IridescentDishWithOlives.glb`    |  80.40 ms |  81.70 ms |       73.00 ms | ⚪ even               | 🔴 1.10x slower   |
-| `LittlestTokyo.glb`               | 118.50 ms | 234.10 ms |      141.10 ms | 🟢 1.98x faster       | 🟢 1.19x faster   |
-| `ShaderBall2.glb`                 |  21.10 ms |  30.10 ms |       22.60 ms | 🟢 1.43x faster       | 🟢 1.07x faster   |
-| `bath_day.glb`                    |  51.30 ms |  65.50 ms |       54.10 ms | 🟢 1.28x faster       | 🟢 1.05x faster   |
-| `duck.glb`                        |   2.60 ms |   3.90 ms |        2.80 ms | 🟢 1.50x faster       | 🟢 1.08x faster   |
-| `ferrari.glb`                     |  40.70 ms | 137.10 ms |       40.60 ms | 🟢 3.37x faster       | ⚪ even           |
-| `forest_house.glb`                |  36.60 ms |  45.00 ms |       37.10 ms | 🟢 1.23x faster       | ⚪ even           |
-| `gears.glb`                       |   3.50 ms |   6.90 ms |        3.00 ms | 🟢 1.97x faster       | 🔴 1.17x slower   |
-| `kira.glb`                        | 292.90 ms | 281.10 ms |      266.70 ms | ⚪ even               | 🔴 1.10x slower   |
-| `minimalistic_modern_bedroom.glb` |  36.40 ms |  41.90 ms |       35.00 ms | 🟢 1.15x faster       | ⚪ even           |
-| `nemetona.glb`                    | 248.40 ms | 260.10 ms |      221.90 ms | ⚪ even               | 🔴 1.12x slower   |
-| `pool.glb`                        | 111.80 ms |  77.90 ms |      101.20 ms | 🔴 1.44x slower       | 🔴 1.10x slower   |
-| `rolex.glb`                       |  45.30 ms | 122.70 ms |       40.80 ms | 🟢 2.71x faster       | 🔴 1.11x slower   |
-| `venice_mask.glb`                 | 138.30 ms | 258.60 ms |      148.10 ms | 🟢 1.87x faster       | 🟢 1.07x faster   |
+| `manablade-characters.glb`        |   4.80 ms |  10.00 ms |        3.30 ms | 🟢 2.08x faster       | 🔴 1.45x slower   |
+| `manablade-static.glb`            |  47.10 ms | 115.80 ms |       36.40 ms | 🟢 2.46x faster       | 🔴 1.29x slower   |
+| `IridescentDishWithOlives.glb`    |  87.50 ms |  82.50 ms |       77.60 ms | 🔴 1.06x slower       | 🔴 1.13x slower   |
+| `LittlestTokyo.glb`               | 113.30 ms | 237.80 ms |      113.50 ms | 🟢 2.10x faster       | ⚪ even           |
+| `ShaderBall2.glb`                 |  19.30 ms |  27.90 ms |       21.10 ms | 🟢 1.45x faster       | 🟢 1.09x faster   |
+| `bath_day.glb`                    |  56.80 ms |  65.30 ms |       53.40 ms | 🟢 1.15x faster       | 🔴 1.06x slower   |
+| `duck.glb`                        |   2.50 ms |   4.30 ms |        2.70 ms | 🟢 1.72x faster       | 🟢 1.08x faster   |
+| `ferrari.glb`                     |  40.70 ms | 126.30 ms |       42.00 ms | 🟢 3.10x faster       | ⚪ even           |
+| `forest_house.glb`                |  35.90 ms |  45.10 ms |       34.90 ms | 🟢 1.26x faster       | ⚪ even           |
+| `gears.glb`                       |   3.60 ms |   7.60 ms |        3.20 ms | 🟢 2.11x faster       | 🔴 1.13x slower   |
+| `kira.glb`                        | 317.30 ms | 314.70 ms |      290.80 ms | ⚪ even               | 🔴 1.09x slower   |
+| `minimalistic_modern_bedroom.glb` |  38.00 ms |  46.60 ms |       39.30 ms | 🟢 1.23x faster       | ⚪ even           |
+| `nemetona.glb`                    | 249.70 ms | 279.80 ms |      210.80 ms | 🟢 1.12x faster       | 🔴 1.18x slower   |
+| `pool.glb`                        |  72.70 ms |  67.50 ms |       76.40 ms | 🔴 1.08x slower       | 🟢 1.05x faster   |
+| `rolex.glb`                       |  34.10 ms |  99.40 ms |       33.70 ms | 🟢 2.91x faster       | ⚪ even           |
+| `venice_mask.glb`                 | 103.40 ms | 233.70 ms |       97.90 ms | 🟢 2.26x faster       | 🔴 1.06x slower   |
 
 Medians of independent runs carry roughly ±10% JIT/thermal noise (more for the loader wall
 clock) — treat this as the cross-decoder picture, not a micro-optimization ranking.

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Median across a 19-model corpus vs [draco.js](https://github.com/mrdoob/draco.js
 
 | benchmark                                     | vs draco.js     | vs draco3d wasm |
 | --------------------------------------------- | --------------- | --------------- |
-| single-threaded decode — bun (JSC)            | 🟢 1.19× faster | 🟢 1.21× faster |
-| single-threaded decode — Chrome (V8)          | 🟢 1.21× faster | ⚪ even         |
-| `GLTFLoader.parse`, worker pool — Chrome (V8) | 🟢 1.46× faster | 🔴 1.06× slower |
+| single-threaded decode — bun (JSC)            | 🟢 1.18× faster | 🟢 1.25× faster |
+| single-threaded decode — Chrome (V8)          | 🟢 1.21× faster | 🟢 1.05× faster |
+| `GLTFLoader.parse`, worker pool — Chrome (V8) | 🟢 1.58× faster | ⚪ even         |
 
-Faster than draco.js across the corpus, ahead of or even with the wasm decoder single-threaded,
-and competitive in a real `GLTFLoader.parse` with the main thread left free.
+Faster than draco.js across the corpus, ahead of the wasm decoder single-threaded, and even with
+it in a real `GLTFLoader.parse` with the main thread left free.
 
 🟢 There's no `draco_decoder.wasm` to fetch and compile before the first decode, so minidraco (and draco.js) often beat the wasm decoder on first load (not reflected on the benchmark).
 

--- a/library/src/decoder/attributes/PointAttribute.ts
+++ b/library/src/decoder/attributes/PointAttribute.ts
@@ -159,6 +159,14 @@ class PointAttribute extends GeometryAttribute {
     this._indicesMap = new Uint32Array(numPoints)
   }
 
+  // Adopts an already-computed map, shared with other attributes of the same
+  // mesh. The map must be treated as read-only from here on (reads go through
+  // mappedIndex/extractTo; copyFrom slices).
+  setExplicitMappingShared(map: Uint32Array): void {
+    this._identityMapping = false
+    this._indicesMap = map
+  }
+
   // Like setExplicitMappingUnfilled, but from decode-scoped scratch. Only for
   // attributes that never escape the decode (see ScratchArena) -- the portable
   // attributes the sequential decoders build and discard.

--- a/library/src/decoder/compression/attributes/SequentialIntegerAttributeDecoder.ts
+++ b/library/src/decoder/compression/attributes/SequentialIntegerAttributeDecoder.ts
@@ -121,17 +121,32 @@ class SequentialIntegerAttributeDecoder extends SequentialAttributeDecoder {
       }
     }
 
-    if (numValues > 0 && (this._predictionScheme === null || !this._predictionScheme.areCorrectionsPositive())) {
-      // Reinterpret the Int32Array as Uint32 for the signed conversion.
-      const asUint32 = new Uint32Array(portableAttributeData.buffer, portableAttributeData.byteOffset, numValues)
-      convertSymbolsToSignedInts(asUint32, numValues, portableAttributeData)
-    }
+    const needsZigzag =
+      numValues > 0 && (this._predictionScheme === null || !this._predictionScheme.areCorrectionsPositive())
 
     if (this._predictionScheme) {
       if (!this._predictionScheme.decodePredictionData(buffer)) {
         return false
       }
       if (numValues > 0) {
+        // Prefer the zigzag-fused decode: it unpacks each correction inline
+        // instead of paying a separate whole-array conversion pass first.
+        if (needsZigzag) {
+          const fused = this._predictionScheme.computeOriginalValuesZigzag(
+            portableAttributeData,
+            portableAttributeData,
+            numValues,
+            numComponents,
+            pointIds,
+          )
+          if (fused !== undefined) {
+            return fused
+          }
+        }
+        if (needsZigzag) {
+          const asUint32 = new Uint32Array(portableAttributeData.buffer, portableAttributeData.byteOffset, numValues)
+          convertSymbolsToSignedInts(asUint32, numValues, portableAttributeData)
+        }
         if (
           !this._predictionScheme.computeOriginalValues(
             portableAttributeData,
@@ -144,6 +159,10 @@ class SequentialIntegerAttributeDecoder extends SequentialAttributeDecoder {
           return false
         }
       }
+    } else if (needsZigzag) {
+      // Reinterpret the Int32Array as Uint32 for the signed conversion.
+      const asUint32 = new Uint32Array(portableAttributeData.buffer, portableAttributeData.byteOffset, numValues)
+      convertSymbolsToSignedInts(asUint32, numValues, portableAttributeData)
     }
     return true
   }

--- a/library/src/decoder/compression/attributes/prediction_schemes/MeshPredictionSchemeParallelogramDecoder.ts
+++ b/library/src/decoder/compression/attributes/prediction_schemes/MeshPredictionSchemeParallelogramDecoder.ts
@@ -25,6 +25,27 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
     return this._meshData.isInitialized()
   }
 
+  // Zigzag-fused variant: decodes corrections that are still in their unsigned
+  // zigzag form, unpacking each one inline. Only offered for the wrap
+  // transform (whose corrections are the only zigzag-coded ones this scheme
+  // sees); callers fall back to the standalone conversion pass otherwise.
+  override computeOriginalValuesZigzag(
+    inCorr: Int32Array,
+    outData: Int32Array,
+    _size: number,
+    numComponents: number,
+    _entryToPointIdMap: Int32Array,
+  ): boolean | undefined {
+    this._transform.init(numComponents)
+    if (
+      !this._transform.getType ||
+      this._transform.getType() !== PredictionSchemeTransformType.PREDICTION_TRANSFORM_WRAP
+    ) {
+      return undefined // Not fusable; caller uses the two-pass path.
+    }
+    return this._computeOriginalValuesWrap(inCorr, outData, numComponents, true)
+  }
+
   override computeOriginalValues(
     inCorr: Int32Array,
     outData: Int32Array,
@@ -38,7 +59,7 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
       this._transform.getType &&
       this._transform.getType() === PredictionSchemeTransformType.PREDICTION_TRANSFORM_WRAP
     ) {
-      return this._computeOriginalValuesWrap(inCorr, outData, numComponents)
+      return this._computeOriginalValuesWrap(inCorr, outData, numComponents, false)
     }
 
     const table = this._meshData.cornerTable
@@ -90,12 +111,18 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
     return true
   }
 
-  _computeOriginalValuesWrap(inCorr: Int32Array, outData: Int32Array, numComponents: number): boolean {
+  // The wrap transform's corrections are zigzag-coded; with `zigzag` set the
+  // decode folds the (val >>> 1) ^ -(val & 1) unpacking into each correction
+  // read, replacing the standalone convertSymbolsToSignedInts pass over the
+  // whole array (see computeOriginalValuesZigzag). Every correction is read
+  // exactly once before its slot is overwritten, so the in-place aliasing of
+  // inCorr and outData is preserved.
+  _computeOriginalValuesWrap(inCorr: Int32Array, outData: Int32Array, numComponents: number, zigzag: boolean): boolean {
     if (numComponents === 2) {
-      return this._computeOriginalValuesWrap2(inCorr, outData)
+      return this._computeOriginalValuesWrap2(inCorr, outData, zigzag)
     }
     if (numComponents === 3) {
-      return this._computeOriginalValuesWrap3(inCorr, outData)
+      return this._computeOriginalValuesWrap3(inCorr, outData, zigzag)
     }
 
     const table = this._meshData.cornerTable
@@ -115,7 +142,8 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
       } else if (pred < minValue) {
         pred = minValue
       }
-      let orig = (pred + inCorr[c]) | 0
+      const raw = inCorr[c]
+      let orig = (pred + (zigzag ? (raw >>> 1) ^ -(raw & 1) : raw)) | 0
       if (orig > maxValue) {
         orig -= maxDif
       } else if (orig < minValue) {
@@ -159,7 +187,8 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
           } else if (pred < minValue) {
             pred = minValue
           }
-          let orig = (pred + inCorr[dstOffset + c]) | 0
+          const raw = inCorr[dstOffset + c]
+          let orig = (pred + (zigzag ? (raw >>> 1) ^ -(raw & 1) : raw)) | 0
           if (orig > maxValue) {
             orig -= maxDif
           } else if (orig < minValue) {
@@ -176,7 +205,8 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
           } else if (pred < minValue) {
             pred = minValue
           }
-          let orig = (pred + inCorr[dstOffset + c]) | 0
+          const raw = inCorr[dstOffset + c]
+          let orig = (pred + (zigzag ? (raw >>> 1) ^ -(raw & 1) : raw)) | 0
           if (orig > maxValue) {
             orig -= maxDif
           } else if (orig < minValue) {
@@ -190,7 +220,7 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
     return true
   }
 
-  _computeOriginalValuesWrap2(inCorr: Int32Array, outData: Int32Array): boolean {
+  _computeOriginalValuesWrap2(inCorr: Int32Array, outData: Int32Array, zigzag: boolean): boolean {
     const table = this._meshData.cornerTable
     const vertexToDataMap = this._meshData.vertexToDataMap
     const oppositeCorners = table.oppositeCornerArray() as Int32Array
@@ -212,8 +242,10 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
     } else if (pred1 < minValue) {
       pred1 = minValue
     }
-    let orig0 = (pred0 + inCorr[0]) | 0
-    let orig1 = (pred1 + inCorr[1]) | 0
+    const raw0 = inCorr[0]
+    const raw1 = inCorr[1]
+    let orig0 = (pred0 + (zigzag ? (raw0 >>> 1) ^ -(raw0 & 1) : raw0)) | 0
+    let orig1 = (pred1 + (zigzag ? (raw1 >>> 1) ^ -(raw1 & 1) : raw1)) | 0
     if (orig0 > maxValue) {
       orig0 -= maxDif
     } else if (orig0 < minValue) {
@@ -269,8 +301,10 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
       } else if (pred1 < minValue) {
         pred1 = minValue
       }
-      orig0 = (pred0 + inCorr[dstOffset]) | 0
-      orig1 = (pred1 + inCorr[dstOffset + 1]) | 0
+      const rawA = inCorr[dstOffset]
+      const rawB = inCorr[dstOffset + 1]
+      orig0 = (pred0 + (zigzag ? (rawA >>> 1) ^ -(rawA & 1) : rawA)) | 0
+      orig1 = (pred1 + (zigzag ? (rawB >>> 1) ^ -(rawB & 1) : rawB)) | 0
       if (orig0 > maxValue) {
         orig0 -= maxDif
       } else if (orig0 < minValue) {
@@ -288,7 +322,7 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
     return true
   }
 
-  _computeOriginalValuesWrap3(inCorr: Int32Array, outData: Int32Array): boolean {
+  _computeOriginalValuesWrap3(inCorr: Int32Array, outData: Int32Array, zigzag: boolean): boolean {
     const table = this._meshData.cornerTable
     const vertexToDataMap = this._meshData.vertexToDataMap
     const oppositeCorners = table.oppositeCornerArray() as Int32Array
@@ -316,9 +350,12 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
     } else if (pred2 < minValue) {
       pred2 = minValue
     }
-    let orig0 = (pred0 + inCorr[0]) | 0
-    let orig1 = (pred1 + inCorr[1]) | 0
-    let orig2 = (pred2 + inCorr[2]) | 0
+    const raw0 = inCorr[0]
+    const raw1 = inCorr[1]
+    const raw2 = inCorr[2]
+    let orig0 = (pred0 + (zigzag ? (raw0 >>> 1) ^ -(raw0 & 1) : raw0)) | 0
+    let orig1 = (pred1 + (zigzag ? (raw1 >>> 1) ^ -(raw1 & 1) : raw1)) | 0
+    let orig2 = (pred2 + (zigzag ? (raw2 >>> 1) ^ -(raw2 & 1) : raw2)) | 0
     if (orig0 > maxValue) {
       orig0 -= maxDif
     } else if (orig0 < minValue) {
@@ -387,9 +424,12 @@ class MeshPredictionSchemeParallelogramDecoder extends MeshPredictionSchemeDecod
       } else if (pred2 < minValue) {
         pred2 = minValue
       }
-      orig0 = (pred0 + inCorr[dstOffset]) | 0
-      orig1 = (pred1 + inCorr[dstOffset + 1]) | 0
-      orig2 = (pred2 + inCorr[dstOffset + 2]) | 0
+      const rawA = inCorr[dstOffset]
+      const rawB = inCorr[dstOffset + 1]
+      const rawC = inCorr[dstOffset + 2]
+      orig0 = (pred0 + (zigzag ? (rawA >>> 1) ^ -(rawA & 1) : rawA)) | 0
+      orig1 = (pred1 + (zigzag ? (rawB >>> 1) ^ -(rawB & 1) : rawB)) | 0
+      orig2 = (pred2 + (zigzag ? (rawC >>> 1) ^ -(rawC & 1) : rawC)) | 0
       if (orig0 > maxValue) {
         orig0 -= maxDif
       } else if (orig0 < minValue) {

--- a/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeDecoderInterface.ts
+++ b/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeDecoderInterface.ts
@@ -32,6 +32,23 @@ class PredictionSchemeDecoderInterface {
     return true
   }
 
+  /**
+   * Like computeOriginalValues, but inCorr still holds unsigned zigzag-coded
+   * corrections; the implementation unpacks each one inline, replacing the
+   * standalone convertSymbolsToSignedInts pass. Returns undefined when the
+   * scheme/transform combination cannot fuse (the caller then falls back to
+   * the two-pass path). Base implementation: never fusable.
+   */
+  computeOriginalValuesZigzag(
+    _inCorr: Int32Array,
+    _outData: Int32Array,
+    _size: number,
+    _numComponents: number,
+    _entryToPointIdMap: Int32Array,
+  ): boolean | undefined {
+    return undefined
+  }
+
   /** Reverts the prediction applied during encoding, writing original values to outData. */
   computeOriginalValues(
     _inCorr: Int32Array,

--- a/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
+++ b/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
@@ -15,8 +15,11 @@ import {
   TOPOLOGY_L,
   TOPOLOGY_R,
   TOPOLOGY_E,
+  TOPOLOGY_INVALID,
   RIGHT_FACE_EDGE,
+  edgeBreakerSymbolToTopologyId,
 } from './MeshEdgebreakerShared'
+import { MeshEdgebreakerTraversalValenceDecoder } from './MeshEdgebreakerTraversalValenceDecoder'
 import { DepthFirstTraverser } from './traverser/DepthFirstTraverser'
 import { MaxPredictionDegreeTraverser } from './traverser/MaxPredictionDegreeTraverser'
 import { MeshAttributeIndicesEncodingObserver } from './traverser/MeshAttributeIndicesEncodingObserver'
@@ -432,10 +435,42 @@ class MeshEdgebreakerDecoderImpl {
     let vertexCorners = vc._vertexCorners!
     const isVertHole = this._isVertHole
     const traversalDecoder = this._traversalDecoder
+    // Specialize the standard 2.2-bitstream case: the valence decoder's
+    // decodeSymbol() and newActiveCornerReached() run once per symbol, but
+    // _decodeConnectivity exceeds V8's inlining budget so both stay real
+    // polymorphic calls. Hoist the valence decoder's state into locals and
+    // inline the two of them (plus mergeVertices) below; the older traversal
+    // decoders keep the method calls. State touched by the inlined code
+    // (activeContext, lastSymbol) is written back after the loop.
+    const valenceDecoder = traversalDecoder instanceof MeshEdgebreakerTraversalValenceDecoder ? traversalDecoder : null
+    const valences = valenceDecoder !== null ? valenceDecoder._vertexValences : null
+    const contextSymbols = valenceDecoder !== null ? valenceDecoder._contextSymbols : null
+    const contextCounters = valenceDecoder !== null ? valenceDecoder._contextCounters : null
+    const minValence = valenceDecoder !== null ? valenceDecoder._minValence : 0
+    const maxValence = valenceDecoder !== null ? valenceDecoder._maxValence : 0
+    let activeContext = valenceDecoder !== null ? valenceDecoder._activeContext : -1
+    let lastSymbol = valenceDecoder !== null ? valenceDecoder._lastSymbol : -1
     for (let symbolId = 0; symbolId < numSymbols; ++symbolId) {
       const faceIndex = numFacesDecoded++
       let checkTopologySplit = false
-      const symbol = traversalDecoder.decodeSymbol()
+      let symbol: number
+      if (valenceDecoder !== null) {
+        // Inlined MeshEdgebreakerTraversalValenceDecoder.decodeSymbol().
+        if (activeContext !== -1) {
+          const contextCounter = --contextCounters![activeContext]
+          if (contextCounter < 0) {
+            symbol = TOPOLOGY_INVALID
+          } else {
+            const rawSymbolId = contextSymbols![activeContext][contextCounter]
+            symbol = rawSymbolId > 4 ? TOPOLOGY_INVALID : edgeBreakerSymbolToTopologyId[rawSymbolId]
+          }
+        } else {
+          symbol = TOPOLOGY_E // The first symbol is always E.
+        }
+        lastSymbol = symbol
+      } else {
+        symbol = traversalDecoder.decodeSymbol()
+      }
 
       if (symbol === TOPOLOGY_C) {
         // Create a new face between two edges on the open boundary.
@@ -556,7 +591,11 @@ class MeshEdgebreakerDecoderImpl {
 
         let cornerN = cornerB % 3 === 2 ? cornerB - 2 : cornerB + 1 // next(cornerB)
         const vertexN = cornerToVertex[cornerN]
-        traversalDecoder.mergeVertices(vertexP, vertexN)
+        if (valences !== null) {
+          valences[vertexP] += valences[vertexN] // inlined mergeVertices
+        } else {
+          traversalDecoder.mergeVertices(vertexP, vertexN)
+        }
         // Update the left-most corner on the newly merged vertex.
         vertexCorners[vertexP] = vertexCorners[vertexN] // leftMostCorner(vertexN)
 
@@ -608,7 +647,48 @@ class MeshEdgebreakerDecoderImpl {
         return -1 // unknown symbol
       }
 
-      traversalDecoder.newActiveCornerReached(activeCornerStack[activeCornerStackSize - 1])
+      if (valences !== null) {
+        // Inlined newActiveCornerReached(): bump the valences of the new
+        // face's vertices per symbol type, then pick the entropy context from
+        // the clamped valence of the next vertex.
+        const activeCorner = activeCornerStack[activeCornerStackSize - 1]
+        const nextC = activeCorner % 3 === 2 ? activeCorner - 2 : activeCorner + 1
+        const prevC = activeCorner % 3 === 0 ? activeCorner + 2 : activeCorner - 1
+        const vertNext = cornerToVertex[nextC]
+        const vertPrev = cornerToVertex[prevC]
+
+        switch (lastSymbol) {
+          case TOPOLOGY_C:
+          case TOPOLOGY_S:
+            valences[vertNext] += 1
+            valences[vertPrev] += 1
+            break
+          case TOPOLOGY_R:
+            valences[cornerToVertex[activeCorner]] += 1
+            valences[vertNext] += 1
+            valences[vertPrev] += 2
+            break
+          case TOPOLOGY_L:
+            valences[cornerToVertex[activeCorner]] += 1
+            valences[vertNext] += 2
+            valences[vertPrev] += 1
+            break
+          case TOPOLOGY_E:
+            valences[cornerToVertex[activeCorner]] += 2
+            valences[vertNext] += 2
+            valences[vertPrev] += 2
+            break
+          default:
+            break
+        }
+
+        const activeValence = valences[vertNext]
+        const clampedValence =
+          activeValence < minValence ? minValence : activeValence > maxValence ? maxValence : activeValence
+        activeContext = clampedValence - minValence
+      } else {
+        traversalDecoder.newActiveCornerReached(activeCornerStack[activeCornerStackSize - 1])
+      }
 
       if (checkTopologySplit) {
         const encoderSymbolId = numSymbols - symbolId - 1
@@ -630,6 +710,11 @@ class MeshEdgebreakerDecoderImpl {
           topologySplitActiveCorners.set(decoderSplitSymbolId, newActiveCorner)
         }
       }
+    }
+
+    if (valenceDecoder !== null) {
+      valenceDecoder._activeContext = activeContext
+      valenceDecoder._lastSymbol = lastSymbol
     }
 
     if (vc._numVertices > maxNumVertices) {

--- a/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
+++ b/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
@@ -15,11 +15,8 @@ import {
   TOPOLOGY_L,
   TOPOLOGY_R,
   TOPOLOGY_E,
-  TOPOLOGY_INVALID,
   RIGHT_FACE_EDGE,
-  edgeBreakerSymbolToTopologyId,
 } from './MeshEdgebreakerShared'
-import { MeshEdgebreakerTraversalValenceDecoder } from './MeshEdgebreakerTraversalValenceDecoder'
 import { DepthFirstTraverser } from './traverser/DepthFirstTraverser'
 import { MaxPredictionDegreeTraverser } from './traverser/MaxPredictionDegreeTraverser'
 import { MeshAttributeIndicesEncodingObserver } from './traverser/MeshAttributeIndicesEncodingObserver'
@@ -436,42 +433,10 @@ class MeshEdgebreakerDecoderImpl {
     let vertexCorners = vc._vertexCorners!
     const isVertHole = this._isVertHole
     const traversalDecoder = this._traversalDecoder
-    // Specialize the standard 2.2-bitstream case: the valence decoder's
-    // decodeSymbol() and newActiveCornerReached() run once per symbol, but
-    // _decodeConnectivity exceeds V8's inlining budget so both stay real
-    // polymorphic calls. Hoist the valence decoder's state into locals and
-    // inline the two of them (plus mergeVertices) below; the older traversal
-    // decoders keep the method calls. State touched by the inlined code
-    // (activeContext, lastSymbol) is written back after the loop.
-    const valenceDecoder = traversalDecoder instanceof MeshEdgebreakerTraversalValenceDecoder ? traversalDecoder : null
-    const valences = valenceDecoder !== null ? valenceDecoder._vertexValences : null
-    const contextSymbols = valenceDecoder !== null ? valenceDecoder._contextSymbols : null
-    const contextCounters = valenceDecoder !== null ? valenceDecoder._contextCounters : null
-    const minValence = valenceDecoder !== null ? valenceDecoder._minValence : 0
-    const maxValence = valenceDecoder !== null ? valenceDecoder._maxValence : 0
-    let activeContext = valenceDecoder !== null ? valenceDecoder._activeContext : -1
-    let lastSymbol = valenceDecoder !== null ? valenceDecoder._lastSymbol : -1
     for (let symbolId = 0; symbolId < numSymbols; ++symbolId) {
       const faceIndex = numFacesDecoded++
       let checkTopologySplit = false
-      let symbol: number
-      if (valenceDecoder !== null) {
-        // Inlined MeshEdgebreakerTraversalValenceDecoder.decodeSymbol().
-        if (activeContext !== -1) {
-          const contextCounter = --contextCounters![activeContext]
-          if (contextCounter < 0) {
-            symbol = TOPOLOGY_INVALID
-          } else {
-            const rawSymbolId = contextSymbols![activeContext][contextCounter]
-            symbol = rawSymbolId > 4 ? TOPOLOGY_INVALID : edgeBreakerSymbolToTopologyId[rawSymbolId]
-          }
-        } else {
-          symbol = TOPOLOGY_E // The first symbol is always E.
-        }
-        lastSymbol = symbol
-      } else {
-        symbol = traversalDecoder.decodeSymbol()
-      }
+      const symbol = traversalDecoder.decodeSymbol()
 
       if (symbol === TOPOLOGY_C) {
         // Create a new face between two edges on the open boundary.
@@ -592,11 +557,7 @@ class MeshEdgebreakerDecoderImpl {
 
         let cornerN = cornerB % 3 === 2 ? cornerB - 2 : cornerB + 1 // next(cornerB)
         const vertexN = cornerToVertex[cornerN]
-        if (valences !== null) {
-          valences[vertexP] += valences[vertexN] // inlined mergeVertices
-        } else {
-          traversalDecoder.mergeVertices(vertexP, vertexN)
-        }
+        traversalDecoder.mergeVertices(vertexP, vertexN)
         // Update the left-most corner on the newly merged vertex.
         vertexCorners[vertexP] = vertexCorners[vertexN] // leftMostCorner(vertexN)
 
@@ -648,48 +609,7 @@ class MeshEdgebreakerDecoderImpl {
         return -1 // unknown symbol
       }
 
-      if (valences !== null) {
-        // Inlined newActiveCornerReached(): bump the valences of the new
-        // face's vertices per symbol type, then pick the entropy context from
-        // the clamped valence of the next vertex.
-        const activeCorner = activeCornerStack[activeCornerStackSize - 1]
-        const nextC = activeCorner % 3 === 2 ? activeCorner - 2 : activeCorner + 1
-        const prevC = activeCorner % 3 === 0 ? activeCorner + 2 : activeCorner - 1
-        const vertNext = cornerToVertex[nextC]
-        const vertPrev = cornerToVertex[prevC]
-
-        switch (lastSymbol) {
-          case TOPOLOGY_C:
-          case TOPOLOGY_S:
-            valences[vertNext] += 1
-            valences[vertPrev] += 1
-            break
-          case TOPOLOGY_R:
-            valences[cornerToVertex[activeCorner]] += 1
-            valences[vertNext] += 1
-            valences[vertPrev] += 2
-            break
-          case TOPOLOGY_L:
-            valences[cornerToVertex[activeCorner]] += 1
-            valences[vertNext] += 2
-            valences[vertPrev] += 1
-            break
-          case TOPOLOGY_E:
-            valences[cornerToVertex[activeCorner]] += 2
-            valences[vertNext] += 2
-            valences[vertPrev] += 2
-            break
-          default:
-            break
-        }
-
-        const activeValence = valences[vertNext]
-        const clampedValence =
-          activeValence < minValence ? minValence : activeValence > maxValence ? maxValence : activeValence
-        activeContext = clampedValence - minValence
-      } else {
-        traversalDecoder.newActiveCornerReached(activeCornerStack[activeCornerStackSize - 1])
-      }
+      traversalDecoder.newActiveCornerReached(activeCornerStack[activeCornerStackSize - 1])
 
       if (checkTopologySplit) {
         const encoderSymbolId = numSymbols - symbolId - 1
@@ -711,11 +631,6 @@ class MeshEdgebreakerDecoderImpl {
           topologySplitActiveCorners.set(decoderSplitSymbolId, newActiveCorner)
         }
       }
-    }
-
-    if (valenceDecoder !== null) {
-      valenceDecoder._activeContext = activeContext
-      valenceDecoder._lastSymbol = lastSymbol
     }
 
     if (vc._numVertices > maxNumVertices) {

--- a/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
+++ b/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
@@ -332,6 +332,7 @@ class MeshEdgebreakerDecoderImpl {
         connectivityData.adoptFrom(previousConnectivityData!)
       } else {
         connectivityData.initEmpty(this._cornerTable)
+        connectivityData.reserveSeamEdges(seamCount)
         for (let s = 0; s < seamCount; ++s) {
           connectivityData.addSeamEdge(seamCorners[s])
         }

--- a/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
+++ b/library/src/decoder/compression/mesh/MeshEdgebreakerDecoderImpl.ts
@@ -1124,9 +1124,11 @@ class MeshAttributeIndicesEncodingData {
     // Int32Array (non-negative data indices) keeps the hot prediction-lookup
     // reads monomorphic. Decode-scoped scratch: both maps are consumed by the
     // attribute decoders of this primitive and never escape into the result.
-    // The vertex map is zero-filled because vertices that no face reaches are
-    // never written by the traversal but can still be read back.
-    this._vertexToEncodedAttributeValueIndexMap = scratchInt32Filled(numVertices, 0)
+    // The vertex map is filled with -1 so the depth-first traverser can use
+    // the sign as its vertex-visited flag (assigned entries are always >= 0);
+    // vertices no face reaches keep -1, and are never read back on well-formed
+    // input (the traversal covers every face corner's vertex).
+    this._vertexToEncodedAttributeValueIndexMap = scratchInt32Filled(numVertices, -1)
     this._encodedAttributeValueIndexToCornerMap = scratchInt32(numVertices)
     this._numValues = 0
   }

--- a/library/src/decoder/compression/mesh/traverser/DepthFirstTraverser.ts
+++ b/library/src/decoder/compression/mesh/traverser/DepthFirstTraverser.ts
@@ -71,7 +71,10 @@ class DepthFirstTraverser {
   onTraversalStart(): void {
     const cornerTable = this._cornerTable!
     this._isFaceVisited = scratchUint8Zeroed(cornerTable.numFaces())
-    this._isVertexVisited = scratchUint8Zeroed(cornerTable.numVertices())
+    // No separate vertex-visited flags: the observer's vertexToEncodedMap is
+    // -1-filled by MeshAttributeIndicesEncodingData.init and every visit
+    // assigns a value index >= 0, so its sign doubles as the visited flag --
+    // one fewer random-access array in the hottest loop.
     this._cornerTraversalStack = scratchInt32(this._numCorners)
   }
 
@@ -83,7 +86,6 @@ class DepthFirstTraverser {
     }
 
     const isFaceVisited = this._isFaceVisited!
-    const isVertexVisited = this._isVertexVisited!
     const observer = this._observer!
     const cornerToVertex = this._cornerToVertex!
     const oppositeCorners = this._oppositeCorners!
@@ -114,14 +116,12 @@ class DepthFirstTraverser {
     if (nextVert === kInvalidVertexIndex || prevVert === kInvalidVertexIndex) {
       return false
     }
-    if (!isVertexVisited[nextVert]) {
-      isVertexVisited[nextVert] = 1
+    if (vertexToEncodedMap[nextVert] < 0) {
       outPointIds[numOutPoints++] = obsFaces[nextCorner]
       encodedToCornerMap[numValues] = nextCorner
       vertexToEncodedMap[nextVert] = numValues++
     }
-    if (!isVertexVisited[prevVert]) {
-      isVertexVisited[prevVert] = 1
+    if (vertexToEncodedMap[prevVert] < 0) {
       outPointIds[numOutPoints++] = obsFaces[prevCorner]
       encodedToCornerMap[numValues] = prevCorner
       vertexToEncodedMap[prevVert] = numValues++
@@ -154,7 +154,7 @@ class DepthFirstTraverser {
         }
         const faceBase = faceId * 3
         const nextCornerId = cornerId === faceBase + 2 ? faceBase : cornerId + 1
-        if (!isVertexVisited[vertId]) {
+        if (vertexToEncodedMap[vertId] < 0) {
           // Inlined isOnBoundary
           // An out-of-range vertex yields undefined here, and `undefined >= 0`
           // is false, so the range check needs no separate guard.
@@ -164,7 +164,6 @@ class DepthFirstTraverser {
             const nextLc = lc % 3 === 2 ? lc - 2 : lc + 1
             onBoundary = oppositeCorners[nextLc] < 0
           }
-          isVertexVisited[vertId] = 1
           outPointIds[numOutPoints++] = obsFaces[cornerId]
           encodedToCornerMap[numValues] = cornerId
           vertexToEncodedMap[vertId] = numValues++

--- a/library/src/decoder/compression/mesh/traverser/MeshTraversalSequencer.ts
+++ b/library/src/decoder/compression/mesh/traverser/MeshTraversalSequencer.ts
@@ -8,12 +8,16 @@ import type { MeshAttributeIndicesEncodingData } from '../MeshEdgebreakerDecoder
 import type { DepthFirstTraverser } from './DepthFirstTraverser'
 import type { MaxPredictionDegreeTraverser } from './MaxPredictionDegreeTraverser'
 
-// Cached result of one traversal (see generateSequence below).
+// Cached result of one traversal (see generateSequence below). indicesMap is
+// filled in lazily by updatePointToAttributeIndexMapping: every attribute
+// whose traversal resolved to this entry gets an identical point-to-value
+// map, so the first one computed is shared by the rest (read-only downstream).
 export type TraversalCacheEntry = {
   pointIds: Int32Array
   vertexMap: Int32Array
   cornerMap: Int32Array
   numValues: number
+  indicesMap: Uint32Array | null
 }
 
 // Per-decode cache: corner-to-vertex array -> traversal method id -> result.
@@ -28,6 +32,9 @@ class MeshTraversalSequencer {
   _outPointIds: Int32Array
   _numOutPoints: number
   _traversalCache: TraversalCache | null
+  // The cache entry the last generateSequence resolved to (hit or store);
+  // carries the shared indicesMap.
+  _cacheEntry: TraversalCacheEntry | null
 
   constructor(
     mesh: Mesh,
@@ -42,6 +49,7 @@ class MeshTraversalSequencer {
     // Optional per-decode cache, keyed by corner table, shared across the
     // attribute decoders of one mesh (see MeshEdgebreakerDecoderImpl).
     this._traversalCache = traversalCache
+    this._cacheEntry = null
   }
 
   setTraverser(traverser: DepthFirstTraverser | MaxPredictionDegreeTraverser): void {
@@ -68,6 +76,7 @@ class MeshTraversalSequencer {
       if (cached !== undefined) {
         this._outPointIds = cached.pointIds
         this._encodingData.adoptTraversalResult(cached.vertexMap, cached.cornerMap, cached.numValues)
+        this._cacheEntry = cached
         return true
       }
     }
@@ -87,12 +96,15 @@ class MeshTraversalSequencer {
         byMethod = new Map()
         this._traversalCache.set(cacheKey, byMethod)
       }
-      byMethod.set(methodId, {
+      const entry: TraversalCacheEntry = {
         pointIds: this._outPointIds,
         vertexMap: this._encodingData.vertexToEncodedAttributeValueIndexMap,
         cornerMap: this._encodingData.encodedAttributeValueIndexToCornerMap,
         numValues: this._encodingData.numValues,
-      })
+        indicesMap: null,
+      }
+      byMethod.set(methodId, entry)
+      this._cacheEntry = entry
     }
     return true
   }
@@ -106,6 +118,17 @@ class MeshTraversalSequencer {
   }
 
   updatePointToAttributeIndexMapping(attribute: PointAttribute): boolean {
+    // The map is a pure function of (faces_, cornerToVertex, vertexToAttEntry),
+    // all fixed within one traversal-cache entry — every attribute that
+    // resolved to the same entry gets an identical map, so share the first one
+    // computed instead of re-walking every corner per attribute. The map is
+    // read-only downstream (extractTo / copyFrom, which slices).
+    const entry = this._cacheEntry
+    if (entry !== null && entry.indicesMap !== null) {
+      attribute.setExplicitMappingShared(entry.indicesMap)
+      return true
+    }
+
     const cornerTable = this._traverser!.cornerTable()!
     const numFaces = this._mesh.numFaces()
     const numPoints = this._mesh.numPoints()
@@ -132,6 +155,9 @@ class MeshTraversalSequencer {
         return false
       }
       indicesMap[pointId] = attEntryId
+    }
+    if (entry !== null) {
+      entry.indicesMap = attribute.indicesMap as Uint32Array
     }
     return true
   }

--- a/library/src/decoder/mesh/MeshAttributeCornerTable.ts
+++ b/library/src/decoder/mesh/MeshAttributeCornerTable.ts
@@ -22,7 +22,11 @@ class MeshAttributeCornerTable {
   _effectiveOpposite: Int32Array | null
   // Every corner passed to addSeamEdge (may contain duplicates); lets
   // oppositeCornerArray patch seams without scanning every corner's flag.
-  _seamCorners: number[]
+  // Preallocated to its exact upper bound (2 per seam edge) by the caller via
+  // reserveSeamEdges -- a plain array grown by push() was measurable on
+  // seam-heavy files.
+  _seamCorners: Int32Array | number[]
+  _numSeamCorners: number
 
   constructor() {
     this.is_edge_on_seam_ = []
@@ -34,6 +38,7 @@ class MeshAttributeCornerTable {
     this.corner_table_ = null
     this._effectiveOpposite = null
     this._seamCorners = []
+    this._numSeamCorners = 0
   }
 
   initEmpty(table: CornerTable | null): boolean {
@@ -53,9 +58,17 @@ class MeshAttributeCornerTable {
     // Lazily built; see oppositeCornerArray.
     this._effectiveOpposite = null
     this._seamCorners = []
+    this._numSeamCorners = 0
     this.corner_table_ = table
     this.no_interior_seams_ = true
     return true
+  }
+
+  // Sizes the seam-corner list for numSeamEdges upcoming addSeamEdge calls
+  // (each adds at most two corners). Decode-scoped scratch.
+  reserveSeamEdges(numSeamEdges: number): void {
+    this._seamCorners = scratchInt32(numSeamEdges * 2)
+    this._numSeamCorners = 0
   }
 
   addSeamEdge(c: number): void {
@@ -63,9 +76,10 @@ class MeshAttributeCornerTable {
     const oppositeCorners = this.corner_table_!.oppositeCornerArray()
     const isEdge = this.is_edge_on_seam_
     const isVert = this.is_vertex_on_seam_
+    const seamCorners = this._seamCorners
 
     isEdge[c] = 1
-    this._seamCorners.push(c)
+    seamCorners[this._numSeamCorners++] = c
     // Inlined next(c)/previous(c).
     let rem = c - ((c / 3) | 0) * 3
     isVert[cornerToVertex[rem === 2 ? c - 2 : c + 1]] = 1
@@ -75,7 +89,7 @@ class MeshAttributeCornerTable {
     if (oppCorner !== kInvalidCornerIndex) {
       this.no_interior_seams_ = false
       isEdge[oppCorner] = 1
-      this._seamCorners.push(oppCorner)
+      seamCorners[this._numSeamCorners++] = oppCorner
       rem = oppCorner - ((oppCorner / 3) | 0) * 3
       isVert[cornerToVertex[rem === 2 ? oppCorner - 2 : oppCorner + 1]] = 1
       isVert[cornerToVertex[rem === 0 ? oppCorner + 2 : oppCorner - 1]] = 1
@@ -226,7 +240,8 @@ class MeshAttributeCornerTable {
       const nc = this.corner_table_!.numCorners()
       const base = this.corner_table_!.oppositeCornerArray()
       const seamCorners = this._seamCorners
-      if (seamCorners.length === 0) {
+      const numSeamCorners = this._numSeamCorners
+      if (numSeamCorners === 0) {
         // No seams: the base connectivity is already correct, share it.
         // (It is read-only after connectivity decoding.)
         this._effectiveOpposite = base
@@ -238,7 +253,7 @@ class MeshAttributeCornerTable {
         // cache entries that may share it) never outlives the decode.
         const eff = scratchInt32(nc)
         eff.set(base.length === nc ? base : base.subarray(0, nc))
-        for (let i = 0, l = seamCorners.length; i < l; ++i) {
+        for (let i = 0; i < numSeamCorners; ++i) {
           eff[seamCorners[i]] = kInvalidCornerIndex
         }
         this._effectiveOpposite = eff
@@ -269,6 +284,7 @@ class MeshAttributeCornerTable {
     this.no_interior_seams_ = other.no_interior_seams_
     this._effectiveOpposite = other._effectiveOpposite
     this._seamCorners = other._seamCorners
+    this._numSeamCorners = other._numSeamCorners
   }
 }
 


### PR DESCRIPTION
A second optimization pass over the decoder, following the same protocol as #3: every change gated on **byte-identical output** across the full 43-file corpus (sha256 over faces + every attribute) and on interleaved A/B benchmarks, with non-wins reverted.

## Changes

- **Shared point-index maps** — attributes that resolve to the same traversal-cache entry produce identical point→value maps; compute once per entry, share the read-only array.
- **DFS visited flag folded into the vertex map** — the traverser's separate visited byte-array is gone; the vertex→value map is −1-filled and its sign carries the flag, removing one random-access array (and a zero-fill) from the hottest loop.
- **Zigzag fused into parallelogram wrap decode** — wrap corrections were unpacked in a standalone whole-array pass; the parallelogram decoder now unzigzags inline at each correction's single read site.
- **Seam-corner lists preallocated** from the decode arena instead of `push()`-grown arrays.

## A cross-engine lesson (see ad76153)

Inlining the valence decoder's per-symbol work into `_decodeConnectivity` was a clear V8 win (−9% on bunny) but pushed the function past **JavaScriptCore's optimizing-tier size threshold**: once a large workload had warmed the process, bunny.drc decoded ~40% slower under bun/Safari — and dead-code experiments confirmed sheer bytecode size, not the executed path, was the trigger. It's backed out; JSC now beats main on that workload too.

## Results

Baseline is the current `main` tip (the merge of #3), so these are gains **on top of** round 1. All three columns measured against the final post-revert build: node/bun interleaved A/B (min of 25 alternating trials, two runs), Chrome as fresh-isolate page loads in both orders.

| model | node (V8) | bun (JSC) | Chrome fresh-isolate |
|---|---|---|---|
| ferrari.glb | −5.5 to −6.8% | −7.3% | −6 to −7% |
| kira.glb | −5.8 to −6.1% | −6.4 to −7.1% | −5 to −8% |
| manablade-static.glb | −2.5 to −2.9% | −1.5 to −2.1% | −1 to −2% |
| bunny.drc | −3.2 to −3.5% | ~even† | ~even |

†bunny under JSC was the regression the backed-out commit fixed; in corpus-warmed processes it now measures at-or-better than main.

## Benchmarks refreshed

`BENCH.json` / `BENCH.browser.json` / `BENCH.md` regenerated on a cooled machine; README medians updated: **1.18×/1.21× faster than draco.js** (bun / Chrome raw), **1.25×/1.05× faster than wasm**, and in a real `GLTFLoader.parse` **1.58× faster than draco.js and now even with wasm** (was 1.06× slower).

Full pipeline green at every commit (format, lint, typecheck, warden, 51 tests / 9,902 assertions — the hooks run it on commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwx5ZhkKSsPs1HPjyfgvQc
