### PR TITLE
perf round 6: coarse rANS tables, fused normal decode, honest loader benchmarks

### DIFF
--- a/BENCH.browser.json
+++ b/BENCH.browser.json
@@ -1,6 +1,6 @@
 {
   "singleThreaded": {
-    "date": "2026-08-27",
+    "date": "2026-09-02",
     "runtime": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
     "benchmark": "raw decode, all decoders sync on main thread",
     "warmupRuns": 3,
@@ -11,9 +11,9 @@
         "primitives": 493,
         "faces": 77544,
         "medianMs": {
-          "minidraco": 35.3,
-          "draco.js": 45.4,
-          "draco3d (wasm)": 35.4
+          "minidraco": 26.5,
+          "draco.js": 35.2,
+          "draco3d (wasm)": 27.1
         }
       },
       {
@@ -21,9 +21,9 @@
         "primitives": 4,
         "faces": 24448,
         "medianMs": {
-          "minidraco": 4.8,
-          "draco.js": 6.3,
-          "draco3d (wasm)": 5.7
+          "minidraco": 3.8,
+          "draco.js": 5.2,
+          "draco3d (wasm)": 4.7
         }
       },
       {
@@ -31,9 +31,9 @@
         "primitives": 71,
         "faces": 141802,
         "medianMs": {
-          "minidraco": 94.9,
-          "draco.js": 105.6,
-          "draco3d (wasm)": 95.8
+          "minidraco": 75,
+          "draco.js": 86.1,
+          "draco3d (wasm)": 75.4
         }
       },
       {
@@ -41,9 +41,9 @@
         "primitives": 3,
         "faces": 13388,
         "medianMs": {
-          "minidraco": 5.7,
-          "draco.js": 6.7,
-          "draco3d (wasm)": 6.1
+          "minidraco": 4.4,
+          "draco.js": 5.4,
+          "draco3d (wasm)": 4.9
         }
       },
       {
@@ -51,9 +51,9 @@
         "primitives": 22,
         "faces": 32158,
         "medianMs": {
-          "minidraco": 6.5,
-          "draco.js": 8.3,
-          "draco3d (wasm)": 7
+          "minidraco": 5.1,
+          "draco.js": 6.6,
+          "draco3d (wasm)": 5.6
         }
       },
       {
@@ -61,9 +61,9 @@
         "primitives": 1,
         "faces": 4212,
         "medianMs": {
-          "minidraco": 1.1,
-          "draco.js": 1.4,
-          "draco3d (wasm)": 1.4
+          "minidraco": 0.8,
+          "draco.js": 1.1,
+          "draco3d (wasm)": 1.1
         }
       },
       {
@@ -71,9 +71,9 @@
         "primitives": 51,
         "faces": 358788,
         "medianMs": {
-          "minidraco": 82,
-          "draco.js": 99.8,
-          "draco3d (wasm)": 97.5
+          "minidraco": 61.7,
+          "draco.js": 79,
+          "draco3d (wasm)": 76.1
         }
       },
       {
@@ -81,9 +81,9 @@
         "primitives": 12,
         "faces": 10956,
         "medianMs": {
-          "minidraco": 3.1,
-          "draco.js": 3.9,
-          "draco3d (wasm)": 3.4
+          "minidraco": 2.4,
+          "draco.js": 3.2,
+          "draco3d (wasm)": 2.7
         }
       },
       {
@@ -91,9 +91,9 @@
         "primitives": 3,
         "faces": 21696,
         "medianMs": {
-          "minidraco": 4,
-          "draco.js": 5.2,
-          "draco3d (wasm)": 4.2
+          "minidraco": 3,
+          "draco.js": 4,
+          "draco3d (wasm)": 3.4
         }
       },
       {
@@ -101,9 +101,9 @@
         "primitives": 43,
         "faces": 51601,
         "medianMs": {
-          "minidraco": 12.7,
-          "draco.js": 16.4,
-          "draco3d (wasm)": 14.7
+          "minidraco": 9.2,
+          "draco.js": 12.7,
+          "draco3d (wasm)": 11.2
         }
       },
       {
@@ -111,9 +111,9 @@
         "primitives": 4,
         "faces": 10457,
         "medianMs": {
-          "minidraco": 3.9,
-          "draco.js": 4.3,
-          "draco3d (wasm)": 3.9
+          "minidraco": 2.8,
+          "draco.js": 3.4,
+          "draco3d (wasm)": 3.1
         }
       },
       {
@@ -121,9 +121,9 @@
         "primitives": 1,
         "faces": 320352,
         "medianMs": {
-          "minidraco": 178.2,
-          "draco.js": 201,
-          "draco3d (wasm)": 175.7
+          "minidraco": 136.4,
+          "draco.js": 159.1,
+          "draco3d (wasm)": 136.4
         }
       },
       {
@@ -131,9 +131,9 @@
         "primitives": 2,
         "faces": 22280,
         "medianMs": {
-          "minidraco": 5.5,
-          "draco.js": 6.9,
-          "draco3d (wasm)": 5.1
+          "minidraco": 4.1,
+          "draco.js": 5.1,
+          "draco3d (wasm)": 3.9
         }
       },
       {
@@ -141,9 +141,9 @@
         "primitives": 24,
         "faces": 120336,
         "medianMs": {
-          "minidraco": 49.3,
-          "draco.js": 58.2,
-          "draco3d (wasm)": 50.5
+          "minidraco": 38,
+          "draco.js": 44.2,
+          "draco3d (wasm)": 39.9
         }
       },
       {
@@ -151,9 +151,9 @@
         "primitives": 5,
         "faces": 295600,
         "medianMs": {
-          "minidraco": 98,
-          "draco.js": 116.8,
-          "draco3d (wasm)": 99.4
+          "minidraco": 78.4,
+          "draco.js": 92.7,
+          "draco3d (wasm)": 78.7
         }
       },
       {
@@ -161,9 +161,9 @@
         "primitives": 1,
         "faces": 69451,
         "medianMs": {
-          "minidraco": 6,
-          "draco.js": 7.9,
-          "draco3d (wasm)": 5.4
+          "minidraco": 4.5,
+          "draco.js": 5.6,
+          "draco3d (wasm)": 4.1
         }
       },
       {
@@ -171,8 +171,8 @@
         "primitives": 1,
         "faces": 1744,
         "medianMs": {
-          "minidraco": 0,
-          "draco.js": 3,
+          "minidraco": 0.1,
+          "draco.js": 2.7,
           "draco3d (wasm)": 0.2
         }
       },
@@ -181,138 +181,267 @@
         "primitives": 1,
         "faces": 4212,
         "medianMs": {
-          "minidraco": 1.2,
-          "draco.js": 1.4,
-          "draco3d (wasm)": 1.3
+          "minidraco": 0.9,
+          "draco.js": 1.2,
+          "draco3d (wasm)": 1.1
         }
       }
     ]
   },
   "multiThreaded": {
-    "date": "2026-08-27",
+    "date": "2026-09-02",
     "runtime": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
     "benchmark": "GLTFLoader wall clock; minidraco + wasm on 4-worker pools, draco.js main thread",
-    "warmupRuns": 1,
+    "warmupRuns": 5,
     "timedRuns": 5,
     "results": [
       {
         "file": "manablade-bundle.glb",
         "medianMs": {
-          "minidraco": 34.5,
-          "draco.js": 66,
-          "draco3d (wasm)": 23.1
+          "minidraco": 17.5,
+          "draco.js": 46.6,
+          "draco3d (wasm)": 17.1
         }
       },
       {
         "file": "IridescentDishWithOlives.glb",
         "medianMs": {
-          "minidraco": 83.9,
-          "draco.js": 76.6,
-          "draco3d (wasm)": 69.2
+          "minidraco": 47.5,
+          "draco.js": 52.1,
+          "draco3d (wasm)": 48
         }
       },
       {
         "file": "LittlestTokyo.glb",
         "medianMs": {
-          "minidraco": 107.2,
-          "draco.js": 209.2,
-          "draco3d (wasm)": 96.4
+          "minidraco": 65.8,
+          "draco.js": 154.8,
+          "draco3d (wasm)": 65.3
         }
       },
       {
         "file": "ShaderBall2.glb",
         "medianMs": {
-          "minidraco": 17.1,
-          "draco.js": 24.9,
-          "draco3d (wasm)": 16.4
+          "minidraco": 12.5,
+          "draco.js": 20.3,
+          "draco3d (wasm)": 12.3
         }
       },
       {
         "file": "bath_day.glb",
         "medianMs": {
-          "minidraco": 46.3,
-          "draco.js": 59.1,
-          "draco3d (wasm)": 47.1
+          "minidraco": 34,
+          "draco.js": 41.9,
+          "draco3d (wasm)": 33.5
         }
       },
       {
         "file": "duck.glb",
         "medianMs": {
-          "minidraco": 2,
-          "draco.js": 3.8,
-          "draco3d (wasm)": 2.1
+          "minidraco": 1.6,
+          "draco.js": 2.3,
+          "draco3d (wasm)": 1.5
         }
       },
       {
         "file": "ferrari.glb",
         "medianMs": {
-          "minidraco": 34.8,
-          "draco.js": 111.3,
-          "draco3d (wasm)": 33.8
+          "minidraco": 22.1,
+          "draco.js": 83.1,
+          "draco3d (wasm)": 24.4
         }
       },
       {
         "file": "forest_house.glb",
         "medianMs": {
-          "minidraco": 35.1,
-          "draco.js": 35.7,
-          "draco3d (wasm)": 27
+          "minidraco": 21.1,
+          "draco.js": 24.2,
+          "draco3d (wasm)": 20
         }
       },
       {
         "file": "gears.glb",
         "medianMs": {
-          "minidraco": 2.7,
-          "draco.js": 6.3,
-          "draco3d (wasm)": 2.4
+          "minidraco": 1.7,
+          "draco.js": 4.8,
+          "draco3d (wasm)": 1.8
         }
       },
       {
         "file": "kira.glb",
         "medianMs": {
-          "minidraco": 272.4,
-          "draco.js": 278,
-          "draco3d (wasm)": 258.5
+          "minidraco": 199.4,
+          "draco.js": 212.6,
+          "draco3d (wasm)": 200.5
+        }
+      },
+      {
+        "file": "minimalistic_modern_bedroom.glb",
+        "medianMs": {
+          "minidraco": 25.7,
+          "draco.js": 29.6,
+          "draco3d (wasm)": 25.5
+        }
+      },
+      {
+        "file": "nemetona.glb",
+        "medianMs": {
+          "minidraco": 146.3,
+          "draco.js": 281.1,
+          "draco3d (wasm)": 140.4
+        }
+      },
+      {
+        "file": "pool.glb",
+        "medianMs": {
+          "minidraco": 37.7,
+          "draco.js": 41.6,
+          "draco3d (wasm)": 39.9
+        }
+      },
+      {
+        "file": "rolex.glb",
+        "medianMs": {
+          "minidraco": 16.1,
+          "draco.js": 59.7,
+          "draco3d (wasm)": 22.4
+        }
+      },
+      {
+        "file": "venice_mask.glb",
+        "medianMs": {
+          "minidraco": 58,
+          "draco.js": 145.5,
+          "draco3d (wasm)": 57.3
+        }
+      }
+    ]
+  },
+  "coldLoad": {
+    "date": "2026-09-02",
+    "runtime": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+    "benchmark": "GLTFLoader wall clock, fresh loader per trial preloaded 300 ms before the parse",
+    "warmupRuns": 0,
+    "timedRuns": 3,
+    "results": [
+      {
+        "file": "manablade-bundle.glb",
+        "medianMs": {
+          "minidraco": 56.5,
+          "draco.js": 88.3,
+          "draco3d (wasm)": 38.4
+        }
+      },
+      {
+        "file": "IridescentDishWithOlives.glb",
+        "medianMs": {
+          "minidraco": 59.9,
+          "draco.js": 80.8,
+          "draco3d (wasm)": 79.6
+        }
+      },
+      {
+        "file": "LittlestTokyo.glb",
+        "medianMs": {
+          "minidraco": 112.4,
+          "draco.js": 187.8,
+          "draco3d (wasm)": 99.3
+        }
+      },
+      {
+        "file": "ShaderBall2.glb",
+        "medianMs": {
+          "minidraco": 25.6,
+          "draco.js": 40.5,
+          "draco3d (wasm)": 30
+        }
+      },
+      {
+        "file": "bath_day.glb",
+        "medianMs": {
+          "minidraco": 48.4,
+          "draco.js": 55.5,
+          "draco3d (wasm)": 58.6
+        }
+      },
+      {
+        "file": "duck.glb",
+        "medianMs": {
+          "minidraco": 10,
+          "draco.js": 8.1,
+          "draco3d (wasm)": 12.6
+        }
+      },
+      {
+        "file": "ferrari.glb",
+        "medianMs": {
+          "minidraco": 75.1,
+          "draco.js": 110.1,
+          "draco3d (wasm)": 48.5
+        }
+      },
+      {
+        "file": "forest_house.glb",
+        "medianMs": {
+          "minidraco": 36.5,
+          "draco.js": 39.2,
+          "draco3d (wasm)": 56.6
+        }
+      },
+      {
+        "file": "gears.glb",
+        "medianMs": {
+          "minidraco": 10.4,
+          "draco.js": 12.2,
+          "draco3d (wasm)": 15.2
+        }
+      },
+      {
+        "file": "kira.glb",
+        "medianMs": {
+          "minidraco": 243,
+          "draco.js": 262.4,
+          "draco3d (wasm)": 233.7
         }
       },
       {
         "file": "minimalistic_modern_bedroom.glb",
         "medianMs": {
           "minidraco": 32.8,
-          "draco.js": 37.7,
-          "draco3d (wasm)": 33.5
+          "draco.js": 53.3,
+          "draco3d (wasm)": 53.1
         }
       },
       {
         "file": "nemetona.glb",
         "medianMs": {
-          "minidraco": 210.4,
-          "draco.js": 247.9,
-          "draco3d (wasm)": 183
+          "minidraco": 196.2,
+          "draco.js": 214.9,
+          "draco3d (wasm)": 179
         }
       },
       {
         "file": "pool.glb",
         "medianMs": {
-          "minidraco": 92.7,
-          "draco.js": 67,
-          "draco3d (wasm)": 53.8
+          "minidraco": 73.2,
+          "draco.js": 67.5,
+          "draco3d (wasm)": 60.6
         }
       },
       {
         "file": "rolex.glb",
         "medianMs": {
-          "minidraco": 26,
-          "draco.js": 80.6,
-          "draco3d (wasm)": 28.8
+          "minidraco": 67.1,
+          "draco.js": 91.8,
+          "draco3d (wasm)": 47.2
         }
       },
       {
         "file": "venice_mask.glb",
         "medianMs": {
-          "minidraco": 83.9,
-          "draco.js": 192.2,
-          "draco3d (wasm)": 94.1
+          "minidraco": 128.7,
+          "draco.js": 169.1,
+          "draco3d (wasm)": 114.3
         }
       }
     ]

--- a/BENCH.json
+++ b/BENCH.json
@@ -1,6 +1,6 @@
 {
-  "date": "2026-08-27",
-  "runtime": "bun 1.3.14",
+  "date": "2026-09-02",
+  "runtime": "bun 1.4.0",
   "engine": "JavaScriptCore",
   "cpu": "Apple M3",
   "warmupRuns": 3,
@@ -12,9 +12,9 @@
       "points": 130474,
       "faces": 77544,
       "medianMs": {
-        "minidraco": 35.024,
-        "draco.js": 45.098,
-        "draco3d (wasm)": 37.658
+        "minidraco": 23.022,
+        "draco.js": 31.629,
+        "draco3d (wasm)": 26.521
       }
     },
     {
@@ -23,9 +23,9 @@
       "points": 14864,
       "faces": 24448,
       "medianMs": {
-        "minidraco": 4.918,
-        "draco.js": 5.402,
-        "draco3d (wasm)": 6.019
+        "minidraco": 3.064,
+        "draco.js": 4.064,
+        "draco3d (wasm)": 4.303
       }
     },
     {
@@ -34,9 +34,9 @@
       "points": 193125,
       "faces": 141802,
       "medianMs": {
-        "minidraco": 83.111,
-        "draco.js": 94.703,
-        "draco3d (wasm)": 99.005
+        "minidraco": 62.52,
+        "draco.js": 71.372,
+        "draco3d (wasm)": 75.633
       }
     },
     {
@@ -45,9 +45,9 @@
       "points": 8377,
       "faces": 13388,
       "medianMs": {
-        "minidraco": 4.958,
-        "draco.js": 6.048,
-        "draco3d (wasm)": 6.559
+        "minidraco": 3.518,
+        "draco.js": 4.247,
+        "draco3d (wasm)": 4.916
       }
     },
     {
@@ -56,9 +56,9 @@
       "points": 21759,
       "faces": 32158,
       "medianMs": {
-        "minidraco": 7.102,
-        "draco.js": 7.492,
-        "draco3d (wasm)": 7.149
+        "minidraco": 3.998,
+        "draco.js": 5.526,
+        "draco3d (wasm)": 5.512
       }
     },
     {
@@ -67,9 +67,9 @@
       "points": 2277,
       "faces": 4212,
       "medianMs": {
-        "minidraco": 0.867,
-        "draco.js": 1.123,
-        "draco3d (wasm)": 3.37
+        "minidraco": 0.661,
+        "draco.js": 0.812,
+        "draco3d (wasm)": 1.077
       }
     },
     {
@@ -78,9 +78,9 @@
       "points": 337834,
       "faces": 358788,
       "medianMs": {
-        "minidraco": 68.195,
-        "draco.js": 80.11,
-        "draco3d (wasm)": 100.41
+        "minidraco": 47.112,
+        "draco.js": 59.249,
+        "draco3d (wasm)": 75.583
       }
     },
     {
@@ -89,9 +89,9 @@
       "points": 11924,
       "faces": 10956,
       "medianMs": {
-        "minidraco": 2.59,
-        "draco.js": 3.209,
-        "draco3d (wasm)": 3.793
+        "minidraco": 1.915,
+        "draco.js": 2.439,
+        "draco3d (wasm)": 2.654
       }
     },
     {
@@ -100,9 +100,9 @@
       "points": 23426,
       "faces": 21696,
       "medianMs": {
-        "minidraco": 3.373,
-        "draco.js": 3.796,
-        "draco3d (wasm)": 4.472
+        "minidraco": 2.19,
+        "draco.js": 2.967,
+        "draco3d (wasm)": 3.321
       }
     },
     {
@@ -111,9 +111,9 @@
       "points": 55486,
       "faces": 51601,
       "medianMs": {
-        "minidraco": 8.996,
-        "draco.js": 11.4,
-        "draco3d (wasm)": 14.15
+        "minidraco": 6.83,
+        "draco.js": 8.995,
+        "draco3d (wasm)": 10.987
       }
     },
     {
@@ -122,9 +122,9 @@
       "points": 13884,
       "faces": 10457,
       "medianMs": {
-        "minidraco": 2.856,
-        "draco.js": 3.23,
-        "draco3d (wasm)": 3.734
+        "minidraco": 2.274,
+        "draco.js": 2.601,
+        "draco3d (wasm)": 2.935
       }
     },
     {
@@ -133,9 +133,9 @@
       "points": 349197,
       "faces": 320352,
       "medianMs": {
-        "minidraco": 141.117,
-        "draco.js": 164.829,
-        "draco3d (wasm)": 179.039
+        "minidraco": 109.791,
+        "draco.js": 131.881,
+        "draco3d (wasm)": 136.798
       }
     },
     {
@@ -144,9 +144,9 @@
       "points": 13501,
       "faces": 22280,
       "medianMs": {
-        "minidraco": 5.361,
-        "draco.js": 6.887,
-        "draco3d (wasm)": 5.216
+        "minidraco": 3.942,
+        "draco.js": 4.859,
+        "draco3d (wasm)": 3.973
       }
     },
     {
@@ -155,9 +155,9 @@
       "points": 101560,
       "faces": 120336,
       "medianMs": {
-        "minidraco": 39.361,
-        "draco.js": 50.9,
-        "draco3d (wasm)": 53.107
+        "minidraco": 31.578,
+        "draco.js": 37.341,
+        "draco3d (wasm)": 40.327
       }
     },
     {
@@ -166,9 +166,9 @@
       "points": 173876,
       "faces": 295600,
       "medianMs": {
-        "minidraco": 80.639,
-        "draco.js": 97.919,
-        "draco3d (wasm)": 101.644
+        "minidraco": 57.881,
+        "draco.js": 78.391,
+        "draco3d (wasm)": 79.68
       }
     },
     {
@@ -177,9 +177,9 @@
       "points": 34834,
       "faces": 69451,
       "medianMs": {
-        "minidraco": 5.492,
-        "draco.js": 10.748,
-        "draco3d (wasm)": 5.3
+        "minidraco": 6.75,
+        "draco.js": 8.296,
+        "draco3d (wasm)": 4.297
       }
     },
     {
@@ -188,9 +188,9 @@
       "points": 1856,
       "faces": 1744,
       "medianMs": {
-        "minidraco": 0.082,
-        "draco.js": 4.539,
-        "draco3d (wasm)": 0.192
+        "minidraco": 0.057,
+        "draco.js": 1.595,
+        "draco3d (wasm)": 0.132
       }
     },
     {
@@ -199,9 +199,9 @@
       "points": 2277,
       "faces": 4212,
       "medianMs": {
-        "minidraco": 0.923,
-        "draco.js": 1.31,
-        "draco3d (wasm)": 1.334
+        "minidraco": 0.729,
+        "draco.js": 1.052,
+        "draco3d (wasm)": 1.055
       }
     }
   ]

--- a/BENCH.md
+++ b/BENCH.md
@@ -12,88 +12,118 @@ installed dependency). The last two columns say how minidraco compares to each o
 
 Raw decode via `bun run bench`, median of 10 runs after 3 warmups.
 
-- Date: 2026-08-27
-- Runtime: bun 1.3.14 (JavaScriptCore)
+- Date: 2026-09-02
+- Runtime: bun 1.4.0 (JavaScriptCore)
 - CPU: Apple M3
 
 | file                              | prims |   faces | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
 | --------------------------------- | ----: | ------: | --------: | --------: | -------------: | --------------------- | ----------------- |
-| `manablade-bundle.glb`            |   493 |  77,544 |  35.02 ms |  45.10 ms |       37.66 ms | 🟢 1.29x faster       | 🟢 1.08x faster   |
-| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   4.92 ms |   5.40 ms |        6.02 ms | 🟢 1.10x faster       | 🟢 1.22x faster   |
-| `LittlestTokyo.glb`               |    71 | 141,802 |  83.11 ms |  94.70 ms |       99.00 ms | 🟢 1.14x faster       | 🟢 1.19x faster   |
-| `ShaderBall2.glb`                 |     3 |  13,388 |   4.96 ms |   6.05 ms |        6.56 ms | 🟢 1.22x faster       | 🟢 1.32x faster   |
-| `bath_day.glb`                    |    22 |  32,158 |   7.10 ms |   7.49 ms |        7.15 ms | 🟢 1.05x faster       | ⚪ even           |
-| `duck.glb`                        |     1 |   4,212 |   0.87 ms |   1.12 ms |        3.37 ms | 🟢 1.30x faster       | 🟢 3.89x faster   |
-| `ferrari.glb`                     |    51 | 358,788 |  68.19 ms |  80.11 ms |      100.41 ms | 🟢 1.17x faster       | 🟢 1.47x faster   |
-| `forest_house.glb`                |    12 |  10,956 |   2.59 ms |   3.21 ms |        3.79 ms | 🟢 1.24x faster       | 🟢 1.46x faster   |
-| `gears.glb`                       |     3 |  21,696 |   3.37 ms |   3.80 ms |        4.47 ms | 🟢 1.13x faster       | 🟢 1.33x faster   |
-| `kira.glb`                        |    43 |  51,601 |   9.00 ms |  11.40 ms |       14.15 ms | 🟢 1.27x faster       | 🟢 1.57x faster   |
-| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   2.86 ms |   3.23 ms |        3.73 ms | 🟢 1.13x faster       | 🟢 1.31x faster   |
-| `nemetona.glb`                    |     1 | 320,352 | 141.12 ms | 164.83 ms |      179.04 ms | 🟢 1.17x faster       | 🟢 1.27x faster   |
-| `pool.glb`                        |     2 |  22,280 |   5.36 ms |   6.89 ms |        5.22 ms | 🟢 1.28x faster       | ⚪ even           |
-| `rolex.glb`                       |    24 | 120,336 |  39.36 ms |  50.90 ms |       53.11 ms | 🟢 1.29x faster       | 🟢 1.35x faster   |
-| `venice_mask.glb`                 |     5 | 295,600 |  80.64 ms |  97.92 ms |      101.64 ms | 🟢 1.21x faster       | 🟢 1.26x faster   |
-| `bunny.drc`                       |     1 |  69,451 |   5.49 ms |  10.75 ms |        5.30 ms | 🟢 1.96x faster       | ⚪ even           |
-| `car.drc`                         |     1 |   1,744 |   0.08 ms |   4.54 ms |        0.19 ms | 🟢 55.35x faster      | 🟢 2.34x faster   |
-| `duck.drc`                        |     1 |   4,212 |   0.92 ms |   1.31 ms |        1.33 ms | 🟢 1.42x faster       | 🟢 1.45x faster   |
+| `manablade-bundle.glb`            |   493 |  77,544 |  23.02 ms |  31.63 ms |       26.52 ms | 🟢 1.37x faster       | 🟢 1.15x faster   |
+| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   3.06 ms |   4.06 ms |        4.30 ms | 🟢 1.33x faster       | 🟢 1.40x faster   |
+| `LittlestTokyo.glb`               |    71 | 141,802 |  62.52 ms |  71.37 ms |       75.63 ms | 🟢 1.14x faster       | 🟢 1.21x faster   |
+| `ShaderBall2.glb`                 |     3 |  13,388 |   3.52 ms |   4.25 ms |        4.92 ms | 🟢 1.21x faster       | 🟢 1.40x faster   |
+| `bath_day.glb`                    |    22 |  32,158 |   4.00 ms |   5.53 ms |        5.51 ms | 🟢 1.38x faster       | 🟢 1.38x faster   |
+| `duck.glb`                        |     1 |   4,212 |   0.66 ms |   0.81 ms |        1.08 ms | 🟢 1.23x faster       | 🟢 1.63x faster   |
+| `ferrari.glb`                     |    51 | 358,788 |  47.11 ms |  59.25 ms |       75.58 ms | 🟢 1.26x faster       | 🟢 1.60x faster   |
+| `forest_house.glb`                |    12 |  10,956 |   1.92 ms |   2.44 ms |        2.65 ms | 🟢 1.27x faster       | 🟢 1.39x faster   |
+| `gears.glb`                       |     3 |  21,696 |   2.19 ms |   2.97 ms |        3.32 ms | 🟢 1.35x faster       | 🟢 1.52x faster   |
+| `kira.glb`                        |    43 |  51,601 |   6.83 ms |   8.99 ms |       10.99 ms | 🟢 1.32x faster       | 🟢 1.61x faster   |
+| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   2.27 ms |   2.60 ms |        2.94 ms | 🟢 1.14x faster       | 🟢 1.29x faster   |
+| `nemetona.glb`                    |     1 | 320,352 | 109.79 ms | 131.88 ms |      136.80 ms | 🟢 1.20x faster       | 🟢 1.25x faster   |
+| `pool.glb`                        |     2 |  22,280 |   3.94 ms |   4.86 ms |        3.97 ms | 🟢 1.23x faster       | ⚪ even           |
+| `rolex.glb`                       |    24 | 120,336 |  31.58 ms |  37.34 ms |       40.33 ms | 🟢 1.18x faster       | 🟢 1.28x faster   |
+| `venice_mask.glb`                 |     5 | 295,600 |  57.88 ms |  78.39 ms |       79.68 ms | 🟢 1.35x faster       | 🟢 1.38x faster   |
+| `bunny.drc`                       |     1 |  69,451 |   6.75 ms |   8.30 ms |        4.30 ms | 🟢 1.23x faster       | 🔴 1.57x slower   |
+| `car.drc`                         |     1 |   1,744 |   0.06 ms |   1.59 ms |        0.13 ms | 🟢 27.98x faster      | 🟢 2.32x faster   |
+| `duck.drc`                        |     1 |   4,212 |   0.73 ms |   1.05 ms |        1.05 ms | 🟢 1.44x faster       | 🟢 1.45x faster   |
 
 ## Browser — single-threaded raw decode (V8)
 
 All three decoders run synchronously on the main thread — no worker pools, no GLTFLoader
 overhead. Median of 10 runs after 3 warmups, saved from the example's `/bench` page.
 
-- Date: 2026-08-27
+- Date: 2026-09-02
 - Browser: Chrome/151.0.0.0 on Macintosh
 
 | file                              | prims |   faces | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
 | --------------------------------- | ----: | ------: | --------: | --------: | -------------: | --------------------- | ----------------- |
-| `manablade-bundle.glb`            |   493 |  77,544 |  35.30 ms |  45.40 ms |       35.40 ms | 🟢 1.29x faster       | ⚪ even           |
-| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   4.80 ms |   6.30 ms |        5.70 ms | 🟢 1.31x faster       | 🟢 1.19x faster   |
-| `LittlestTokyo.glb`               |    71 | 141,802 |  94.90 ms | 105.60 ms |       95.80 ms | 🟢 1.11x faster       | ⚪ even           |
-| `ShaderBall2.glb`                 |     3 |  13,388 |   5.70 ms |   6.70 ms |        6.10 ms | 🟢 1.18x faster       | 🟢 1.07x faster   |
-| `bath_day.glb`                    |    22 |  32,158 |   6.50 ms |   8.30 ms |        7.00 ms | 🟢 1.28x faster       | 🟢 1.08x faster   |
-| `duck.glb`                        |     1 |   4,212 |   1.10 ms |   1.40 ms |        1.40 ms | 🟢 1.27x faster       | 🟢 1.27x faster   |
-| `ferrari.glb`                     |    51 | 358,788 |  82.00 ms |  99.80 ms |       97.50 ms | 🟢 1.22x faster       | 🟢 1.19x faster   |
-| `forest_house.glb`                |    12 |  10,956 |   3.10 ms |   3.90 ms |        3.40 ms | 🟢 1.26x faster       | 🟢 1.10x faster   |
-| `gears.glb`                       |     3 |  21,696 |   4.00 ms |   5.20 ms |        4.20 ms | 🟢 1.30x faster       | 🟢 1.05x faster   |
-| `kira.glb`                        |    43 |  51,601 |  12.70 ms |  16.40 ms |       14.70 ms | 🟢 1.29x faster       | 🟢 1.16x faster   |
-| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   3.90 ms |   4.30 ms |        3.90 ms | 🟢 1.10x faster       | ⚪ even           |
-| `nemetona.glb`                    |     1 | 320,352 | 178.20 ms | 201.00 ms |      175.70 ms | 🟢 1.13x faster       | ⚪ even           |
-| `pool.glb`                        |     2 |  22,280 |   5.50 ms |   6.90 ms |        5.10 ms | 🟢 1.25x faster       | 🔴 1.08x slower   |
-| `rolex.glb`                       |    24 | 120,336 |  49.30 ms |  58.20 ms |       50.50 ms | 🟢 1.18x faster       | ⚪ even           |
-| `venice_mask.glb`                 |     5 | 295,600 |  98.00 ms | 116.80 ms |       99.40 ms | 🟢 1.19x faster       | ⚪ even           |
-| `bunny.drc`                       |     1 |  69,451 |   6.00 ms |   7.90 ms |        5.40 ms | 🟢 1.32x faster       | 🔴 1.11x slower   |
-| `car.drc`                         |     1 |   1,744 |   0.00 ms |   3.00 ms |        0.20 ms | 🟢 60.00x faster      | 🟢 4.00x faster   |
-| `duck.drc`                        |     1 |   4,212 |   1.20 ms |   1.40 ms |        1.30 ms | 🟢 1.17x faster       | 🟢 1.08x faster   |
+| `manablade-bundle.glb`            |   493 |  77,544 |  26.50 ms |  35.20 ms |       27.10 ms | 🟢 1.33x faster       | ⚪ even           |
+| `IridescentDishWithOlives.glb`    |     4 |  24,448 |   3.80 ms |   5.20 ms |        4.70 ms | 🟢 1.37x faster       | 🟢 1.24x faster   |
+| `LittlestTokyo.glb`               |    71 | 141,802 |  75.00 ms |  86.10 ms |       75.40 ms | 🟢 1.15x faster       | ⚪ even           |
+| `ShaderBall2.glb`                 |     3 |  13,388 |   4.40 ms |   5.40 ms |        4.90 ms | 🟢 1.23x faster       | 🟢 1.11x faster   |
+| `bath_day.glb`                    |    22 |  32,158 |   5.10 ms |   6.60 ms |        5.60 ms | 🟢 1.29x faster       | 🟢 1.10x faster   |
+| `duck.glb`                        |     1 |   4,212 |   0.80 ms |   1.10 ms |        1.10 ms | 🟢 1.38x faster       | 🟢 1.38x faster   |
+| `ferrari.glb`                     |    51 | 358,788 |  61.70 ms |  79.00 ms |       76.10 ms | 🟢 1.28x faster       | 🟢 1.23x faster   |
+| `forest_house.glb`                |    12 |  10,956 |   2.40 ms |   3.20 ms |        2.70 ms | 🟢 1.33x faster       | 🟢 1.13x faster   |
+| `gears.glb`                       |     3 |  21,696 |   3.00 ms |   4.00 ms |        3.40 ms | 🟢 1.33x faster       | 🟢 1.13x faster   |
+| `kira.glb`                        |    43 |  51,601 |   9.20 ms |  12.70 ms |       11.20 ms | 🟢 1.38x faster       | 🟢 1.22x faster   |
+| `minimalistic_modern_bedroom.glb` |     4 |  10,457 |   2.80 ms |   3.40 ms |        3.10 ms | 🟢 1.21x faster       | 🟢 1.11x faster   |
+| `nemetona.glb`                    |     1 | 320,352 | 136.40 ms | 159.10 ms |      136.40 ms | 🟢 1.17x faster       | ⚪ even           |
+| `pool.glb`                        |     2 |  22,280 |   4.10 ms |   5.10 ms |        3.90 ms | 🟢 1.24x faster       | 🔴 1.05x slower   |
+| `rolex.glb`                       |    24 | 120,336 |  38.00 ms |  44.20 ms |       39.90 ms | 🟢 1.16x faster       | 🟢 1.05x faster   |
+| `venice_mask.glb`                 |     5 | 295,600 |  78.40 ms |  92.70 ms |       78.70 ms | 🟢 1.18x faster       | ⚪ even           |
+| `bunny.drc`                       |     1 |  69,451 |   4.50 ms |   5.60 ms |        4.10 ms | 🟢 1.24x faster       | 🔴 1.10x slower   |
+| `car.drc`                         |     1 |   1,744 |   0.10 ms |   2.70 ms |        0.20 ms | 🟢 27.00x faster      | 🟢 2.00x faster   |
+| `duck.drc`                        |     1 |   4,212 |   0.90 ms |   1.20 ms |        1.10 ms | 🟢 1.33x faster       | 🟢 1.22x faster   |
 
 ## Browser — GLTFLoader wall clock (V8)
 
 Full `GLTFLoader.parse` time with long-lived loaders. Not an apples-to-apples decoder
 comparison: minidraco and the wasm decoder parallelize across 4-worker pools while draco.js
 decodes on the main thread — this measures what an app actually experiences, including
-texture decode and scene-graph setup. Median of 5 runs after 1 warmup, GLBs only
-(raw `.drc` files have no glTF container).
+texture decode and scene-graph setup. Median of 5 runs after 5 warmups
+(a fresh worker pool needs a few loads before its JIT settles — see the cold section for the
+first load), GLBs only (raw `.drc` files have no glTF container).
 
-- Date: 2026-08-27
+- Date: 2026-09-02
 - Browser: Chrome/151.0.0.0 on Macintosh
 
 | file                              | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
 | --------------------------------- | --------: | --------: | -------------: | --------------------- | ----------------- |
-| `manablade-bundle.glb`            |  34.50 ms |  66.00 ms |       23.10 ms | 🟢 1.91x faster       | 🔴 1.49x slower   |
-| `IridescentDishWithOlives.glb`    |  83.90 ms |  76.60 ms |       69.20 ms | 🔴 1.10x slower       | 🔴 1.21x slower   |
-| `LittlestTokyo.glb`               | 107.20 ms | 209.20 ms |       96.40 ms | 🟢 1.95x faster       | 🔴 1.11x slower   |
-| `ShaderBall2.glb`                 |  17.10 ms |  24.90 ms |       16.40 ms | 🟢 1.46x faster       | ⚪ even           |
-| `bath_day.glb`                    |  46.30 ms |  59.10 ms |       47.10 ms | 🟢 1.28x faster       | ⚪ even           |
-| `duck.glb`                        |   2.00 ms |   3.80 ms |        2.10 ms | 🟢 1.90x faster       | 🟢 1.05x faster   |
-| `ferrari.glb`                     |  34.80 ms | 111.30 ms |       33.80 ms | 🟢 3.20x faster       | ⚪ even           |
-| `forest_house.glb`                |  35.10 ms |  35.70 ms |       27.00 ms | ⚪ even               | 🔴 1.30x slower   |
-| `gears.glb`                       |   2.70 ms |   6.30 ms |        2.40 ms | 🟢 2.33x faster       | 🔴 1.13x slower   |
-| `kira.glb`                        | 272.40 ms | 278.00 ms |      258.50 ms | ⚪ even               | 🔴 1.05x slower   |
-| `minimalistic_modern_bedroom.glb` |  32.80 ms |  37.70 ms |       33.50 ms | 🟢 1.15x faster       | ⚪ even           |
-| `nemetona.glb`                    | 210.40 ms | 247.90 ms |      183.00 ms | 🟢 1.18x faster       | 🔴 1.15x slower   |
-| `pool.glb`                        |  92.70 ms |  67.00 ms |       53.80 ms | 🔴 1.38x slower       | 🔴 1.72x slower   |
-| `rolex.glb`                       |  26.00 ms |  80.60 ms |       28.80 ms | 🟢 3.10x faster       | 🟢 1.11x faster   |
-| `venice_mask.glb`                 |  83.90 ms | 192.20 ms |       94.10 ms | 🟢 2.29x faster       | 🟢 1.12x faster   |
+| `manablade-bundle.glb`            |  17.50 ms |  46.60 ms |       17.10 ms | 🟢 2.66x faster       | ⚪ even           |
+| `IridescentDishWithOlives.glb`    |  47.50 ms |  52.10 ms |       48.00 ms | 🟢 1.10x faster       | ⚪ even           |
+| `LittlestTokyo.glb`               |  65.80 ms | 154.80 ms |       65.30 ms | 🟢 2.35x faster       | ⚪ even           |
+| `ShaderBall2.glb`                 |  12.50 ms |  20.30 ms |       12.30 ms | 🟢 1.62x faster       | ⚪ even           |
+| `bath_day.glb`                    |  34.00 ms |  41.90 ms |       33.50 ms | 🟢 1.23x faster       | ⚪ even           |
+| `duck.glb`                        |   1.60 ms |   2.30 ms |        1.50 ms | 🟢 1.44x faster       | 🔴 1.07x slower   |
+| `ferrari.glb`                     |  22.10 ms |  83.10 ms |       24.40 ms | 🟢 3.76x faster       | 🟢 1.10x faster   |
+| `forest_house.glb`                |  21.10 ms |  24.20 ms |       20.00 ms | 🟢 1.15x faster       | 🔴 1.06x slower   |
+| `gears.glb`                       |   1.70 ms |   4.80 ms |        1.80 ms | 🟢 2.82x faster       | 🟢 1.06x faster   |
+| `kira.glb`                        | 199.40 ms | 212.60 ms |      200.50 ms | 🟢 1.07x faster       | ⚪ even           |
+| `minimalistic_modern_bedroom.glb` |  25.70 ms |  29.60 ms |       25.50 ms | 🟢 1.15x faster       | ⚪ even           |
+| `nemetona.glb`                    | 146.30 ms | 281.10 ms |      140.40 ms | 🟢 1.92x faster       | ⚪ even           |
+| `pool.glb`                        |  37.70 ms |  41.60 ms |       39.90 ms | 🟢 1.10x faster       | 🟢 1.06x faster   |
+| `rolex.glb`                       |  16.10 ms |  59.70 ms |       22.40 ms | 🟢 3.71x faster       | 🟢 1.39x faster   |
+| `venice_mask.glb`                 |  58.00 ms | 145.50 ms |       57.30 ms | 🟢 2.51x faster       | ⚪ even           |
+
+## Browser — GLTFLoader cold first load (V8)
+
+The first load of a session: a fresh loader per trial (minidraco spawns and JIT-warms its
+worker pool, the wasm decoder downloads and compiles its module), preloaded 300 ms before a
+single `GLTFLoader.parse`. Median of 3 trials. draco.js has no pool or wasm to warm,
+so its column is a plain main-thread parse. Cold numbers swing more than warm ones: an idle
+worker thread also restarts on a slow core on Apple Silicon.
+
+- Date: 2026-09-02
+- Browser: Chrome/151.0.0.0 on Macintosh
+
+| file                              | minidraco |  draco.js | draco3d (wasm) | minidraco vs draco.js | minidraco vs wasm |
+| --------------------------------- | --------: | --------: | -------------: | --------------------- | ----------------- |
+| `manablade-bundle.glb`            |  56.50 ms |  88.30 ms |       38.40 ms | 🟢 1.56x faster       | 🔴 1.47x slower   |
+| `IridescentDishWithOlives.glb`    |  59.90 ms |  80.80 ms |       79.60 ms | 🟢 1.35x faster       | 🟢 1.33x faster   |
+| `LittlestTokyo.glb`               | 112.40 ms | 187.80 ms |       99.30 ms | 🟢 1.67x faster       | 🔴 1.13x slower   |
+| `ShaderBall2.glb`                 |  25.60 ms |  40.50 ms |       30.00 ms | 🟢 1.58x faster       | 🟢 1.17x faster   |
+| `bath_day.glb`                    |  48.40 ms |  55.50 ms |       58.60 ms | 🟢 1.15x faster       | 🟢 1.21x faster   |
+| `duck.glb`                        |  10.00 ms |   8.10 ms |       12.60 ms | 🔴 1.23x slower       | 🟢 1.26x faster   |
+| `ferrari.glb`                     |  75.10 ms | 110.10 ms |       48.50 ms | 🟢 1.47x faster       | 🔴 1.55x slower   |
+| `forest_house.glb`                |  36.50 ms |  39.20 ms |       56.60 ms | 🟢 1.07x faster       | 🟢 1.55x faster   |
+| `gears.glb`                       |  10.40 ms |  12.20 ms |       15.20 ms | 🟢 1.17x faster       | 🟢 1.46x faster   |
+| `kira.glb`                        | 243.00 ms | 262.40 ms |      233.70 ms | 🟢 1.08x faster       | ⚪ even           |
+| `minimalistic_modern_bedroom.glb` |  32.80 ms |  53.30 ms |       53.10 ms | 🟢 1.63x faster       | 🟢 1.62x faster   |
+| `nemetona.glb`                    | 196.20 ms | 214.90 ms |      179.00 ms | 🟢 1.10x faster       | 🔴 1.10x slower   |
+| `pool.glb`                        |  73.20 ms |  67.50 ms |       60.60 ms | 🔴 1.08x slower       | 🔴 1.21x slower   |
+| `rolex.glb`                       |  67.10 ms |  91.80 ms |       47.20 ms | 🟢 1.37x faster       | 🔴 1.42x slower   |
+| `venice_mask.glb`                 | 128.70 ms | 169.10 ms |      114.30 ms | 🟢 1.31x faster       | 🔴 1.13x slower   |
 
 Medians of independent runs carry roughly ±10% JIT/thermal noise (more for the loader wall
 clock) — treat this as the cross-decoder picture, not a micro-optimization ranking.

--- a/README.md
+++ b/README.md
@@ -43,16 +43,17 @@ Median across an 18-model corpus vs [draco.js](https://github.com/mrdoob/draco.j
 [draco3d](https://www.npmjs.com/package/draco3d) wasm decoder (full results in
 [BENCH.md](https://github.com/verekia/minidraco/blob/main/BENCH.md)):
 
-| benchmark                                     | vs draco.js     | vs draco3d wasm |
-| --------------------------------------------- | --------------- | --------------- |
-| single-threaded decode — bun (JSC)            | 🟢 1.23× faster | 🟢 1.32× faster |
-| single-threaded decode — Chrome (V8)          | 🟢 1.26× faster | 🟢 1.06× faster |
-| `GLTFLoader.parse`, worker pool — Chrome (V8) | 🟢 1.46× faster | 🔴 1.05× slower |
+| benchmark                                          | vs draco.js     | vs draco3d wasm |
+| -------------------------------------------------- | --------------- | --------------- |
+| single-threaded decode — bun (JSC)                 | 🟢 1.27× faster | 🟢 1.38× faster |
+| single-threaded decode — Chrome (V8)               | 🟢 1.29× faster | 🟢 1.11× faster |
+| `GLTFLoader.parse`, warm worker pool — Chrome (V8) | 🟢 1.62× faster | ⚪ even         |
+| `GLTFLoader.parse`, cold first load — Chrome (V8)  | 🟢 1.31× faster | ⚪ even         |
 
-Faster than draco.js across the corpus, ahead of the wasm decoder single-threaded, and
-competitive in a real `GLTFLoader.parse` with the main thread left free.
-
-🟢 There's no `draco_decoder.wasm` to fetch and compile before the first decode, so minidraco (and draco.js) often beat the wasm decoder on first load (not reflected on the benchmark).
+Faster than draco.js across the corpus, ahead of the wasm decoder single-threaded, and even with
+it in a real `GLTFLoader.parse` with the main thread left free — both warm and on the first load
+of a session, where minidraco's worker pool is still JIT-warming while the wasm decoder is
+fetching and compiling its module (no `draco_decoder.wasm` to host or download here).
 
 ## Download size
 

--- a/example/next.config.mjs
+++ b/example/next.config.mjs
@@ -34,7 +34,7 @@ const startBenchResultsServer = () => {
     req.on('end', () => {
       try {
         const { section, data } = JSON.parse(body)
-        if (section !== 'singleThreaded' && section !== 'multiThreaded') {
+        if (section !== 'singleThreaded' && section !== 'multiThreaded' && section !== 'coldLoad') {
           return res.writeHead(400).end('unknown section')
         }
 

--- a/example/pages/bench.tsx
+++ b/example/pages/bench.tsx
@@ -6,7 +6,7 @@ import { Decoder as DracoJsDecoder } from 'draco.js/src/compression/Decode.js'
 import { DecoderBuffer as DracoJsDecoderBuffer } from 'draco.js/src/core/DecoderBuffer.js'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 
-import { getDracoLoader } from '../lib/loaders'
+import { createDracoLoader, getDracoLoader } from '../lib/loaders'
 import {
   decodeRawWithDraco3d,
   decodeRawWithDracoJs,
@@ -19,8 +19,16 @@ import type { RawPrimitive } from '../lib/raw-bench'
 
 const BUNDLE_MODELS = [{ name: 'manablade-bundle.glb', url: '/models/manablade-bundle.glb' }]
 
-const LOADER_WARMUP_RUNS = 1
+// The worker pools need several full parses before their JITs settle (a fresh
+// pool decodes this corpus 2-3x slower for its first ~4 loads), so the warm
+// section discards enough runs to measure steady state; the cold section below
+// measures the first load on purpose.
+const LOADER_WARMUP_RUNS = 5
 const LOADER_TIMED_RUNS = 5
+// Cold first load: a fresh loader per trial, preloaded this long before the
+// parse (stands in for the model download the pool would warm up behind).
+const COLD_TRIALS = 3
+const COLD_PRELOAD_MS = 300
 const RAW_WARMUP_RUNS = 3
 const RAW_TIMED_RUNS = 10
 
@@ -155,7 +163,7 @@ const buildResultsJson = (config: object, rows: BenchRow[]) => ({
   })),
 })
 
-type ResultsSection = 'singleThreaded' | 'multiThreaded'
+type ResultsSection = 'singleThreaded' | 'multiThreaded' | 'coldLoad'
 
 // In local dev, next.config.mjs runs a small companion server that merges
 // each section's results into BENCH.browser.json at the repo root, so V8
@@ -395,10 +403,94 @@ const LoaderBenchSection = () => {
   )
 }
 
+// --- Cold first load (fresh loader per trial: worker spawn, wasm fetch/compile, JIT warm-up) ---
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const ColdLoadBenchSection = () => {
+  const { models, sampleCount } = useBenchModels()
+  const [rows, setRows] = useState<BenchRow[]>([])
+  const [running, setRunning] = useState(false)
+  const [status, setStatus] = useState('')
+
+  const run = useCallback(async () => {
+    setRunning(true)
+    setRows([])
+    const results: BenchRow[] = []
+
+    try {
+      for (const model of models.filter(m => m.name.endsWith('.glb'))) {
+        const response = await fetch(model.url)
+        if (!response.ok) throw new Error(`${model.url}: HTTP ${response.status}`)
+        const bytes = await response.arrayBuffer()
+
+        const medianMs: Record<string, number> = {}
+        for (const { kind, label } of LOADER_KINDS) {
+          const trialsMs: number[] = []
+          for (let i = 0; i < COLD_TRIALS; i++) {
+            setStatus(`${model.name} — ${label} (cold trial ${i + 1}/${COLD_TRIALS})…`)
+            // A brand-new loader each time, the way an app's first load sees
+            // it: workers spawn and warm up, wasm downloads and compiles.
+            const dracoLoader = createDracoLoader(kind)
+            dracoLoader.preload()
+            await sleep(COLD_PRELOAD_MS)
+            const gltfLoader = new GLTFLoader()
+            gltfLoader.setDRACOLoader(dracoLoader)
+            const start = performance.now()
+            await gltfLoader.parseAsync(bytes.slice(0), '')
+            trialsMs.push(performance.now() - start)
+            dracoLoader.dispose()
+            await sleep(100)
+          }
+          medianMs[label] = median(trialsMs)
+        }
+
+        results.push({ model: model.name, medianMs })
+        setRows([...results])
+      }
+      setStatus('Done')
+    } catch (error) {
+      setStatus(String(error))
+    } finally {
+      setRunning(false)
+    }
+  }, [models])
+
+  return (
+    <section className="mt-12">
+      <h2 className="mb-2 text-lg font-semibold">GLTFLoader — cold first load</h2>
+      <p className="mb-1 max-w-xl text-sm text-neutral-400">
+        What the first load of a session costs: a fresh loader per trial (worker pool spawned and JIT-warming, or wasm
+        fetched and compiled), preloaded {COLD_PRELOAD_MS} ms before a single GLTFLoader.parse. Median of {COLD_TRIALS}{' '}
+        trials. draco.js has no pool or wasm to warm, so its number is just a main-thread parse.
+      </p>
+      <CorpusNote sampleCount={sampleCount} glbOnly />
+      <RunButton running={running} onClick={run} label="Run cold-load benchmark" />
+      <p className="mb-4 text-sm text-neutral-400">{status}</p>
+      <BenchTable rows={rows} />
+      {!running && (
+        <ResultsActions
+          section="coldLoad"
+          config={{
+            benchmark: `GLTFLoader wall clock, fresh loader per trial preloaded ${COLD_PRELOAD_MS} ms before the parse`,
+            warmupRuns: 0,
+            timedRuns: COLD_TRIALS,
+          }}
+          rows={rows}
+          canSave={(sampleCount ?? 0) > 0}
+        />
+      )}
+    </section>
+  )
+}
+
 const BenchPage = () => {
   // Raw-decoder debug handles for scripted pure-decode benchmarks (no GLTF
   // parse overhead) from the devtools console / automated browser checks.
   useEffect(() => {
+    // Loader-level handles (long-lived pooled loaders + GLTFLoader) for
+    // scripted wall-clock / pool-overlap measurements from the console.
+    ;(window as any).__loaders = { getDracoLoader, GLTFLoader }
     ;(window as any).__decoders = {
       minidraco: (data: Uint8Array) => decodeDracoMesh(data),
       dracoJs: (data: Uint8Array) => {
@@ -416,6 +508,7 @@ const BenchPage = () => {
       <h1 className="mb-8 text-xl font-semibold">minidraco in-browser benchmark</h1>
       <RawBenchSection />
       <LoaderBenchSection />
+      <ColdLoadBenchSection />
     </div>
   )
 }

--- a/library/scripts/benchmd.ts
+++ b/library/scripts/benchmd.ts
@@ -39,6 +39,7 @@ interface BrowserSection {
 interface BrowserResults {
   singleThreaded?: BrowserSection
   multiThreaded?: BrowserSection
+  coldLoad?: BrowserSection
 }
 
 const repoRoot = resolve(import.meta.dir, '../..')
@@ -141,8 +142,9 @@ export const renderBenchMd = (bun: BunResults, browser: BrowserResults | null): 
       'Full `GLTFLoader.parse` time with long-lived loaders. Not an apples-to-apples decoder',
       'comparison: minidraco and the wasm decoder parallelize across 4-worker pools while draco.js',
       'decodes on the main thread — this measures what an app actually experiences, including',
-      `texture decode and scene-graph setup. Median of ${loader.timedRuns} runs after ${loader.warmupRuns} warmup, GLBs only`,
-      '(raw `.drc` files have no glTF container).',
+      `texture decode and scene-graph setup. Median of ${loader.timedRuns} runs after ${loader.warmupRuns} warmups`,
+      '(a fresh worker pool needs a few loads before its JIT settles — see the cold section for the',
+      'first load), GLBs only (raw `.drc` files have no glTF container).',
       '',
       `- Date: ${loader.date}`,
       `- Browser: ${shortBrowser(loader.runtime)}`,
@@ -152,6 +154,26 @@ export const renderBenchMd = (bun: BunResults, browser: BrowserResults | null): 
     )
   } else {
     lines.push('_No saved browser results — run the loader benchmark on the `/bench` page locally and save it._', '')
+  }
+
+  const cold = browser?.coldLoad
+  lines.push('## Browser — GLTFLoader cold first load (V8)', '')
+  if (cold) {
+    lines.push(
+      'The first load of a session: a fresh loader per trial (minidraco spawns and JIT-warms its',
+      'worker pool, the wasm decoder downloads and compiles its module), preloaded 300 ms before a',
+      `single \`GLTFLoader.parse\`. Median of ${cold.timedRuns} trials. draco.js has no pool or wasm to warm,`,
+      'so its column is a plain main-thread parse. Cold numbers swing more than warm ones: an idle',
+      'worker thread also restarts on a slow core on Apple Silicon.',
+      '',
+      `- Date: ${cold.date}`,
+      `- Browser: ${shortBrowser(cold.runtime)}`,
+      '',
+      ...resultsTable(cold.results),
+      '',
+    )
+  } else {
+    lines.push('_No saved browser results — run the cold-load benchmark on the `/bench` page locally and save it._', '')
   }
 
   lines.push(

--- a/library/src/decoder/attributes/AttributeOctahedronTransform.ts
+++ b/library/src/decoder/attributes/AttributeOctahedronTransform.ts
@@ -12,7 +12,6 @@ import type { PointAttribute } from './PointAttribute'
 
 class AttributeOctahedronTransform extends AttributeTransform {
   _quantizationBits: number
-  _tmpVec?: Float32Array
 
   constructor() {
     super()
@@ -56,15 +55,38 @@ class AttributeOctahedronTransform extends AttributeTransform {
     const dstAddr = targetAttribute.getAddress(0)
     const dstF32 = new Float32Array(dstAddr.buffer, dstAddr.byteOffset, numPoints * 3)
 
-    const outVec = this._tmpVec || (this._tmpVec = new Float32Array(3))
+    // OctahedronToolBox.quantizedOctahedralCoordsToUnitVector inlined (keep in
+    // sync): one loop writing straight into the float32 view instead of two
+    // calls and a 3-element temp per point. Every Math.fround is kept exactly
+    // where the toolbox has it -- that float32 rounding sequence is what makes
+    // the normals bit-identical to the WASM decoder.
+    const fround = Math.fround
+    const scale = toolBox._dequantizationScale
     let si = 0
     let di = 0
     for (let i = 0; i < numPoints; i++) {
-      toolBox.quantizedOctahedralCoordsToUnitVector(srcI32[si], srcI32[si + 1], outVec)
+      let y = fround(fround(fround(srcI32[si]) * scale) - 1.0)
+      let z = fround(fround(fround(srcI32[si + 1]) * scale) - 1.0)
       si += 2
-      dstF32[di] = outVec[0]
-      dstF32[di + 1] = outVec[1]
-      dstF32[di + 2] = outVec[2]
+      const x = fround(fround(1.0 - Math.abs(y)) - Math.abs(z))
+
+      let xOffset = -x
+      if (xOffset < 0) xOffset = 0
+
+      y = fround(y + (y < 0 ? xOffset : -xOffset))
+      z = fround(z + (z < 0 ? xOffset : -xOffset))
+
+      const normSquared = fround(fround(fround(x * x) + fround(y * y)) + fround(z * z))
+      if (normSquared < 1e-6) {
+        dstF32[di] = 0
+        dstF32[di + 1] = 0
+        dstF32[di + 2] = 0
+      } else {
+        const d = fround(1.0 / fround(Math.sqrt(normSquared)))
+        dstF32[di] = fround(x * d)
+        dstF32[di + 1] = fround(y * d)
+        dstF32[di + 2] = fround(z * d)
+      }
       di += 3
     }
     return true

--- a/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeDecoder.ts
+++ b/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeDecoder.ts
@@ -23,6 +23,11 @@ interface PredictionSchemeDecodingTransform {
   ): void
   getType?(): number
   quantizationBits?(): number
+  // Optional fused delta loop (value[i] = original(value[i-1], corr[i]) over
+  // the whole attribute). PredictionSchemeDeltaDecoder uses it when present so
+  // hot transforms avoid one virtual call per value; inCorr and outData may
+  // alias, so each correction must be read before its slot is written.
+  computeOriginalValuesDelta?(inCorr: Int32Array, outData: Int32Array, size: number, numComponents: number): void
 }
 
 /**

--- a/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeDeltaDecoder.ts
+++ b/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeDeltaDecoder.ts
@@ -23,15 +23,24 @@ class PredictionSchemeDeltaDecoder extends PredictionSchemeDecoder {
     numComponents: number,
     entryToPointIdMap: Int32Array,
   ): boolean {
-    this._transform.init(numComponents)
+    const transform = this._transform
+    transform.init(numComponents)
+
+    // Transforms that provide a fused loop (the canonicalized octahedral one,
+    // hot for normals) run the whole delta chain in one call instead of one
+    // virtual computeOriginalValue call per value.
+    if (transform.computeOriginalValuesDelta) {
+      transform.computeOriginalValuesDelta(inCorr, outData, size, numComponents)
+      return true
+    }
 
     // First element has an all-zero "predicted" value.
     const zeroVals = new Int32Array(numComponents)
-    this._transform.computeOriginalValue(zeroVals, 0, inCorr, 0, outData, 0)
+    transform.computeOriginalValue(zeroVals, 0, inCorr, 0, outData, 0)
 
     // D(i) = D(i-1) + correction(i).
     for (let i = numComponents; i < size; i += numComponents) {
-      this._transform.computeOriginalValue(outData, i - numComponents, inCorr, i, outData, i)
+      transform.computeOriginalValue(outData, i - numComponents, inCorr, i, outData, i)
     }
 
     return true

--- a/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeNormalOctahedronCanonicalizedDecodingTransform.ts
+++ b/library/src/decoder/compression/attributes/prediction_schemes/PredictionSchemeNormalOctahedronCanonicalizedDecodingTransform.ts
@@ -171,6 +171,160 @@ class PredictionSchemeNormalOctahedronCanonicalizedDecodingTransform extends Pre
     outOrigVals[outOffset] = origS + center
     outOrigVals[outOffset + 1] = origT + center
   }
+
+  // Fused delta loop for PredictionSchemeDeltaDecoder: the whole
+  // value[i] = original(value[i-1], corr[i]) chain in one call, with the
+  // toolbox fields hoisted to locals and the previous output carried in
+  // locals. This is the hot path for PREDICTION_DIFFERENCE normals (one call
+  // per value through the interface was ~8% of decode time on the bundles).
+  // The arithmetic is computeOriginalValue above verbatim -- keep them in
+  // sync; only the plumbing differs.
+  computeOriginalValuesDelta(inCorr: Int32Array, outData: Int32Array, size: number, numComponents: number): void {
+    const toolBox = this._octahedronToolBox
+    const center = toolBox._centerValue
+    const maxQuantizedValue = toolBox._maxQuantizedValue
+
+    // The first element is predicted from an all-zero value. inCorr and
+    // outData alias in practice, so each correction is read before its slot
+    // is written (same order as the per-value calls it replaces).
+    let prevS = 0
+    let prevT = 0
+    for (let i = 0; i < size; i += numComponents) {
+      const corrS = inCorr[i]
+      const corrT = inCorr[i + 1]
+
+      let predS = prevS - center
+      let predT = prevT - center
+
+      const predIsInDiamond = Math.abs(predS) + Math.abs(predT) <= center
+      if (!predIsInDiamond) {
+        let signS = 0
+        let signT = 0
+        if (predS >= 0 && predT >= 0) {
+          signS = 1
+          signT = 1
+        } else if (predS <= 0 && predT <= 0) {
+          signS = -1
+          signT = -1
+        } else {
+          signS = predS > 0 ? 1 : -1
+          signT = predT > 0 ? 1 : -1
+        }
+        const cornerPointS = signS * center
+        const cornerPointT = signT * center
+        let us = (predS * 2 - cornerPointS) | 0
+        let ut = (predT * 2 - cornerPointT) | 0
+        if (signS * signT >= 0) {
+          const temp = us
+          us = -ut
+          ut = -temp
+        } else {
+          const temp = us
+          us = ut
+          ut = temp
+        }
+        predS = ((us + cornerPointS) / 2) | 0
+        predT = ((ut + cornerPointT) / 2) | 0
+      }
+
+      const predIsInBottomLeft = (predS === 0 && predT === 0) || (predS < 0 && predT <= 0)
+
+      let rotationCount = 0
+      if (predS === 0) {
+        if (predT > 0) rotationCount = 3
+        else if (predT < 0) rotationCount = 1
+      } else if (predS > 0) {
+        if (predT >= 0) rotationCount = 2
+        else rotationCount = 1
+      } else {
+        if (predT > 0) rotationCount = 3
+      }
+
+      if (!predIsInBottomLeft) {
+        const s = predS,
+          t = predT
+        // `(-x) | 0` normalises -0 to +0 so V8 keeps the Smi fast path.
+        switch (rotationCount) {
+          case 1:
+            predS = t
+            predT = -s | 0
+            break
+          case 2:
+            predS = -s | 0
+            predT = -t | 0
+            break
+          case 3:
+            predS = -t | 0
+            predT = s
+            break
+        }
+      }
+
+      // Unsigned addition to avoid signed overflow, then modMax (inlined).
+      let origS = (predS + corrS) | 0
+      if (origS > center) origS -= maxQuantizedValue
+      else if (origS < -center) origS += maxQuantizedValue
+      let origT = (predT + corrT) | 0
+      if (origT > center) origT -= maxQuantizedValue
+      else if (origT < -center) origT += maxQuantizedValue
+
+      if (!predIsInBottomLeft) {
+        const s = origS,
+          t = origT
+        switch ((4 - rotationCount) & 3) {
+          case 1:
+            origS = t
+            origT = -s | 0
+            break
+          case 2:
+            origS = -s | 0
+            origT = -t | 0
+            break
+          case 3:
+            origS = -t | 0
+            origT = s
+            break
+        }
+      }
+
+      if (!predIsInDiamond) {
+        let signS = 0
+        let signT = 0
+        if (origS >= 0 && origT >= 0) {
+          signS = 1
+          signT = 1
+        } else if (origS <= 0 && origT <= 0) {
+          signS = -1
+          signT = -1
+        } else {
+          signS = origS > 0 ? 1 : -1
+          signT = origT > 0 ? 1 : -1
+        }
+        const cornerPointS = signS * center
+        const cornerPointT = signT * center
+        let us = (origS * 2 - cornerPointS) | 0
+        let ut = (origT * 2 - cornerPointT) | 0
+        if (signS * signT >= 0) {
+          const temp = us
+          us = -ut
+          ut = -temp
+        } else {
+          const temp = us
+          us = ut
+          ut = temp
+        }
+        origS = ((us + cornerPointS) / 2) | 0
+        origT = ((ut + cornerPointT) / 2) | 0
+      }
+
+      // An Int32Array store applies ToInt32, which `| 0` reproduces exactly, so
+      // carrying the stored value in a local matches re-reading outData.
+      prevS = (origS + center) | 0
+      prevT = (origT + center) | 0
+      outData[i] = prevS
+      outData[i + 1] = prevT
+    }
+  }
 }
 
 export { PredictionSchemeNormalOctahedronCanonicalizedDecodingTransform }

--- a/library/src/decoder/compression/entropy/ANSCoding.ts
+++ b/library/src/decoder/compression/entropy/ANSCoding.ts
@@ -5,6 +5,12 @@ export const ANS_P8_PRECISION = 256
 export const ANS_L_BASE = 4096
 const ANS_IO_BASE = 256
 
+// Short-stream decoding (see RAnsDecoder.ransBuildLookUpTable): a stream whose
+// symbol count times this factor is below the rANS precision skips the full
+// lut for a 2^COARSE_BUCKET_BITS-entry bucket table.
+const COARSE_STREAM_FACTOR = 8
+const COARSE_BUCKET_BITS = 8
+
 function memGetLe16(buf: Uint8Array, offset: number): number {
   return buf[offset] | (buf[offset + 1] << 8)
 }
@@ -104,6 +110,13 @@ export class RAnsDecoder {
   lutTable: Uint8Array | Uint16Array | Uint32Array | null
   probTable: Uint32Array | null
   cumProbTable: Uint32Array | null
+  // Short-stream mode (see ransBuildLookUpTable): no full-precision lut; a
+  // 256-entry bucket table narrows each lookup to a symbol range that a short
+  // cumProb scan finishes. cumProbTable then carries one extra trailing entry
+  // (== ransPrecision) so the scan needs no bounds check.
+  coarse: boolean
+  bucketShift: number
+  bucketTable: Uint16Array | null
   buf: Uint8Array | null
   bufOffset: number
   // First valid byte of this decoder's slice within buf (absolute offsets,
@@ -119,6 +132,9 @@ export class RAnsDecoder {
     this.lutTable = null // Uint32Array
     this.probTable = null // Uint32Array, flat
     this.cumProbTable = null // Uint32Array, flat
+    this.coarse = false
+    this.bucketShift = 0
+    this.bucketTable = null
     // State inlined (not a nested AnsDecoder) so the ransRead() hot loop touches own props.
     this.buf = null
     this.bufOffset = 0
@@ -182,6 +198,10 @@ export class RAnsDecoder {
       tablePool.push(this.cumProbTable)
       this.cumProbTable = null
     }
+    if (this.bucketTable !== null) {
+      tablePool.push(this.bucketTable)
+      this.bucketTable = null
+    }
     return this.state === this.lRansBase
   }
 
@@ -197,7 +217,14 @@ export class RAnsDecoder {
     }
     const quo = state >>> this.ransPrecisionBits
     const rem = state & this.ransPrecisionMask
-    const symbol = this.lutTable![rem]
+    let symbol: number
+    if (this.coarse) {
+      const cumProbTable = this.cumProbTable!
+      symbol = this.bucketTable![rem >> this.bucketShift]
+      while (cumProbTable[symbol + 1] <= rem) symbol++
+    } else {
+      symbol = this.lutTable![rem]
+    }
     this.state = quo * this.probTable![symbol] + rem - this.cumProbTable![symbol]
     this.bufOffset = bufOffset
     return symbol
@@ -210,6 +237,10 @@ export class RAnsDecoder {
   // once here so each loop body stays monomorphic on its concrete type. The
   // three bodies are intentionally identical copies.
   decodeSymbols(out: Uint32Array, count: number): void {
+    if (this.coarse) {
+      this._decodeSymbolsCoarse(out, count)
+      return
+    }
     const lutTable = this.lutTable!
     if (lutTable instanceof Uint8Array) {
       this._decodeSymbolsU8(out, count, lutTable)
@@ -266,6 +297,34 @@ export class RAnsDecoder {
     this.bufOffset = bufOffset
   }
 
+  // Short-stream loop: bucket table + cumProb scan instead of the full lut.
+  // Same state arithmetic as the lut loops, so the output is identical.
+  _decodeSymbolsCoarse(out: Uint32Array, count: number): void {
+    const buf = this.buf!
+    const lRansBase = this.lRansBase
+    const ransPrecisionBits = this.ransPrecisionBits
+    const ransPrecisionMask = this.ransPrecisionMask
+    const probTable = this.probTable!
+    const cumProbTable = this.cumProbTable!
+    const bucketTable = this.bucketTable!
+    const bucketShift = this.bucketShift
+    let state = this.state
+    let bufOffset = this.bufOffset
+    const bufStart = this.bufStart
+    for (let i = 0; i < count; ++i) {
+      while (state < lRansBase && bufOffset > bufStart) {
+        state = (state << 8) | buf[--bufOffset]
+      }
+      const rem = state & ransPrecisionMask
+      let symbol = bucketTable[rem >> bucketShift]
+      while (cumProbTable[symbol + 1] <= rem) symbol++
+      out[i] = symbol
+      state = (state >>> ransPrecisionBits) * probTable[symbol] + rem - cumProbTable[symbol]
+    }
+    this.state = state
+    this.bufOffset = bufOffset
+  }
+
   _decodeSymbolsU32(out: Uint32Array, count: number, lutTable: Uint32Array): void {
     const buf = this.buf!
     const lRansBase = this.lRansBase
@@ -289,29 +348,70 @@ export class RAnsDecoder {
     this.bufOffset = bufOffset
   }
 
-  // Builds the ransPrecision-entry lookup table. Returns false on bad input data.
-  ransBuildLookUpTable(tokenProbs: Uint32Array, numSymbols: number): boolean {
+  // Builds the decoding tables. Returns false on bad input data.
+  //
+  // expectedCount is how many symbols the caller will decode from this stream.
+  // The full lut has ransPrecision (>= 4096) entries, and a primitive-heavy
+  // file builds thousands of them to decode a few dozen symbols each -- on such
+  // files the table builds cost more than the decodes. Short streams therefore
+  // get a coarse 256-entry bucket table (symbol at the start of each
+  // precision/256-wide bucket) and finish each lookup with a scan of the
+  // cumulative probabilities; long streams keep the exact lut, whose per-symbol
+  // cost is lower.
+  ransBuildLookUpTable(tokenProbs: Uint32Array, numSymbols: number, expectedCount: number = 0x7fffffff): boolean {
+    const ransPrecision = this.ransPrecision
+    const coarse = numSymbols <= 65535 && expectedCount * COARSE_STREAM_FACTOR < ransPrecision
+    this.coarse = coarse
+    // Pooled buffers may be oversized; every slot in the used range is written
+    // below (cumProb must land exactly on ransPrecision), so no clearing needed.
+    const probTable = acquirePooled(Uint32Array, numSymbols)
+    // One trailing entry (== ransPrecision) so the coarse scan needs no bound.
+    const cumProbTable = acquirePooled(Uint32Array, numSymbols + 1)
+    this.probTable = probTable
+    this.cumProbTable = cumProbTable
+    let cumProb = 0
+    if (coarse) {
+      this.lutTable = null
+      for (let i = 0; i < numSymbols; ++i) {
+        const prob = tokenProbs[i]
+        probTable[i] = prob
+        cumProbTable[i] = cumProb
+        cumProb += prob
+        if (cumProb > ransPrecision) {
+          return false
+        }
+      }
+      if (cumProb !== ransPrecision) {
+        return false
+      }
+      cumProbTable[numSymbols] = ransPrecision
+      const bucketShift = this.ransPrecisionBits - COARSE_BUCKET_BITS
+      const bucketTable = acquirePooled(Uint16Array, 1 << COARSE_BUCKET_BITS)
+      this.bucketShift = bucketShift
+      this.bucketTable = bucketTable
+      let symbol = 0
+      for (let b = 0; b < 1 << COARSE_BUCKET_BITS; ++b) {
+        const rem = b << bucketShift
+        while (cumProbTable[symbol + 1] <= rem) symbol++
+        bucketTable[b] = symbol
+      }
+      return true
+    }
+
     // lutTable is indexed by `rem` (random in [0, ransPrecision)), so it's the
     // hottest random read in decodeSymbols()/ransRead(). Its values are symbol
     // ids (< numSymbols), so pick the narrowest element type that holds them:
     // shrinking the table (up to 4x) keeps that random access closer to cache.
     const LutArray = numSymbols <= 256 ? Uint8Array : numSymbols <= 65536 ? Uint16Array : Uint32Array
-    // Pooled buffers may be oversized; every slot in the used range is written
-    // below (cumProb must land exactly on ransPrecision), so no clearing needed.
-    const lutTable = acquirePooled(LutArray as new (length: number) => Uint8Array, this.ransPrecision)
-    const probTable = acquirePooled(Uint32Array, numSymbols)
-    const cumProbTable = acquirePooled(Uint32Array, numSymbols)
+    const lutTable = acquirePooled(LutArray as new (length: number) => Uint8Array, ransPrecision)
     this.lutTable = lutTable
-    this.probTable = probTable
-    this.cumProbTable = cumProbTable
-    let cumProb = 0
     let actProb = 0
     for (let i = 0; i < numSymbols; ++i) {
       const prob = tokenProbs[i]
       probTable[i] = prob
       cumProbTable[i] = cumProb
       cumProb += prob
-      if (cumProb > this.ransPrecision) {
+      if (cumProb > ransPrecision) {
         return false
       }
       // Manual loop for short runs: fill()'s per-call overhead dominates them.
@@ -324,9 +424,10 @@ export class RAnsDecoder {
       }
       actProb = cumProb
     }
-    if (cumProb !== this.ransPrecision) {
+    if (cumProb !== ransPrecision) {
       return false
     }
+    cumProbTable[numSymbols] = ransPrecision
     return true
   }
 }

--- a/library/src/decoder/compression/entropy/RAnsSymbolDecoder.ts
+++ b/library/src/decoder/compression/entropy/RAnsSymbolDecoder.ts
@@ -31,8 +31,10 @@ export class RAnsSymbolDecoder {
     return this.numSymbols_
   }
 
-  // Initialize the decoder and decode the probability table.
-  create(buffer: DecoderBuffer): boolean {
+  // Initialize the decoder and decode the probability table. expectedCount is
+  // the number of symbols the caller will decode (lets short streams skip the
+  // full lookup table; see RAnsDecoder.ransBuildLookUpTable).
+  create(buffer: DecoderBuffer, expectedCount: number = 0x7fffffff): boolean {
     if (buffer.bitstreamVersion === 0) {
       return false
     }
@@ -87,7 +89,7 @@ export class RAnsSymbolDecoder {
     }
     buffer.advance(pos - startPos)
 
-    if (!this.ans_.ransBuildLookUpTable(this.probabilityTable_, this.numSymbols_)) {
+    if (!this.ans_.ransBuildLookUpTable(this.probabilityTable_, this.numSymbols_, expectedCount)) {
       return false
     }
     return true

--- a/library/src/decoder/compression/entropy/SymbolDecoding.ts
+++ b/library/src/decoder/compression/entropy/SymbolDecoding.ts
@@ -35,7 +35,8 @@ export function decodeTaggedSymbols(
   outValues: Uint32Array,
 ): boolean {
   const tagDecoder = new RAnsSymbolDecoder(5)
-  if (!tagDecoder.create(srcBuffer)) {
+  // One tag per value group.
+  if (!tagDecoder.create(srcBuffer, Math.ceil(numValues / numComponents))) {
     return false
   }
 
@@ -119,7 +120,7 @@ export function parseRawSymbolStream(numValues: number, srcBuffer: DecoderBuffer
     return null
   }
   const decoder = new RAnsSymbolDecoder(maxBitLength)
-  if (!decoder.create(srcBuffer)) {
+  if (!decoder.create(srcBuffer, numValues)) {
     return null
   }
   if (numValues > 0 && decoder.numSymbols === 0) {
@@ -138,7 +139,7 @@ function decodeRawSymbolsInternal(
   outValues: Uint32Array,
 ): boolean {
   const decoder = new RAnsSymbolDecoder(uniqueSymbolsBitLength)
-  if (!decoder.create(srcBuffer)) {
+  if (!decoder.create(srcBuffer, numValues)) {
     return false
   }
 

--- a/library/src/decoder/compression/mesh/MeshEdgebreakerTraversalValenceDecoder.ts
+++ b/library/src/decoder/compression/mesh/MeshEdgebreakerTraversalValenceDecoder.ts
@@ -131,7 +131,7 @@ class MeshEdgebreakerTraversalValenceDecoder extends MeshEdgebreakerTraversalDec
           return false
         }
         const decoder = new RAnsSymbolDecoder(maxBitLength)
-        if (!decoder.create(outBuffer)) {
+        if (!decoder.create(outBuffer, numSymbols)) {
           return false
         }
         if (decoder.numSymbols === 0) {
@@ -150,39 +150,43 @@ class MeshEdgebreakerTraversalValenceDecoder extends MeshEdgebreakerTraversalDec
     }
 
     // Decode three streams in lockstep while possible (the six contexts make
-    // two clean trios), then pairs, then a lone leftover; non-Uint8 luts
-    // (never produced for these alphabets) decode alone.
-    const allU8 = pending.every(entry => entry.decoder.ans_.lutTable instanceof Uint8Array)
+    // two clean trios), then pairs, then a lone leftover. Only Uint8-lut
+    // streams take part: short streams that chose the coarse tables (see
+    // ransBuildLookUpTable) and non-Uint8 luts (never produced for these
+    // alphabets) decode alone, without dragging the big streams out of the
+    // lockstep loops.
+    const lockstep = pending.filter(entry => entry.decoder.ans_.lutTable instanceof Uint8Array)
     let p = 0
-    if (allU8) {
-      while (pending.length - p >= 3) {
-        const a = pending[p]
-        const b = pending[p + 1]
-        const c = pending[p + 2]
-        ransDecodeSymbolsTrioU8(
-          a.decoder.ans_,
-          a.out,
-          a.count,
-          b.decoder.ans_,
-          b.out,
-          b.count,
-          c.decoder.ans_,
-          c.out,
-          c.count,
-        )
-        p += 3
-      }
-      if (pending.length - p === 2) {
-        const a = pending[p]
-        const b = pending[p + 1]
-        ransDecodeSymbolsPairU8(a.decoder.ans_, a.out, a.count, b.decoder.ans_, b.out, b.count)
-        p += 2
-      }
+    while (lockstep.length - p >= 3) {
+      const a = lockstep[p]
+      const b = lockstep[p + 1]
+      const c = lockstep[p + 2]
+      ransDecodeSymbolsTrioU8(
+        a.decoder.ans_,
+        a.out,
+        a.count,
+        b.decoder.ans_,
+        b.out,
+        b.count,
+        c.decoder.ans_,
+        c.out,
+        c.count,
+      )
+      p += 3
     }
-    for (; p < pending.length; ++p) {
-      pending[p].decoder.ans_.decodeSymbols(pending[p].out, pending[p].count)
+    if (lockstep.length - p === 2) {
+      const a = lockstep[p]
+      const b = lockstep[p + 1]
+      ransDecodeSymbolsPairU8(a.decoder.ans_, a.out, a.count, b.decoder.ans_, b.out, b.count)
+      p += 2
+    }
+    for (; p < lockstep.length; ++p) {
+      lockstep[p].decoder.ans_.decodeSymbols(lockstep[p].out, lockstep[p].count)
     }
     for (const entry of pending) {
+      if (!(entry.decoder.ans_.lutTable instanceof Uint8Array)) {
+        entry.decoder.ans_.decodeSymbols(entry.out, entry.count)
+      }
       entry.decoder.endDecoding()
     }
     return true

--- a/library/src/decoder/compression/point_cloud/PointCloudDecoder.ts
+++ b/library/src/decoder/compression/point_cloud/PointCloudDecoder.ts
@@ -273,14 +273,21 @@ class PointCloudDecoder {
     for (let i = 0; i < decoders.length; i++) {
       decoders[i]!.collectPendingSymbolStreams(pending)
     }
+    // Short streams on the coarse tables (see ransBuildLookUpTable) decode
+    // alone; pairing them would only knock a lut stream out of the lockstep
+    // loop, and they are cheap either way.
+    const paired = pending.filter(stream => !stream.ans.coarse)
     let i = 0
-    for (; i + 1 < pending.length; i += 2) {
-      const a = pending[i]
-      const b = pending[i + 1]
+    for (; i + 1 < paired.length; i += 2) {
+      const a = paired[i]
+      const b = paired[i + 1]
       ransDecodeSymbolsPair(a.ans, a.out, a.count, b.ans, b.out, b.count)
     }
-    if (i < pending.length) {
-      pending[i].ans.decodeSymbols(pending[i].out, pending[i].count)
+    if (i < paired.length) {
+      paired[i].ans.decodeSymbols(paired[i].out, paired[i].count)
+    }
+    for (const stream of pending) {
+      if (stream.ans.coarse) stream.ans.decodeSymbols(stream.out, stream.count)
     }
 
     for (let k = 0; k < decoders.length; k++) {


### PR DESCRIPTION
## Decoder

- **Short rANS streams skip the full lookup table.** Primitive-heavy files built thousands of 4096+-entry tables to decode a few dozen symbols each (~8% of the manablade bundle decode, ~13% of kira). Streams below precision/8 symbols now use a 256-entry bucket table plus a cumulative-probability scan; long streams keep the exact lut, and coarse streams stay out of the pair/trio lockstep loops.
- **Fused delta + canonicalized-octahedron normal decode.** One loop instead of a virtual call per value, with the octahedral-to-unit-vector conversion inlined into dequantization; same integer arithmetic and float32 rounding.

Output is bit-identical (49 fidelity tests). Interleaved A/B vs the previous build: V8 bundle about −10%, kira / rolex / LittlestTokyo / nemetona −4 to −8%; JSC neutral (normals −3%, coarse tables +3%).

## Benchmarks

- The loader wall-clock section discarded one warm-up run, but a fresh worker pool decodes this corpus 2-3x slower for its first ~4 loads (per-worker JIT tier-up), so it was measuring cold JIT rather than the decoder. It now discards 5, and a new **cold first load** section measures the first load on purpose (fresh loader per trial, preloaded 300 ms before one parse).
- BENCH.json / BENCH.browser.json / BENCH.md / README refreshed. Corpus medians vs wasm: bun 1.38x, Chrome single-threaded 1.11x, warm loader even (was reported as 1.05x slower), cold loader even.

## Not shipped, measured (see BENCH.md cold section)

Cold first parse of the bundle is ~56 ms vs ~38 ms for wasm on a fresh loader; pool size does not change it and a better warm-up mesh set only buys a few ms. Idle worker threads also restart 1.5-4x slower on Apple Silicon (affects wasm workers too), which is why sub-20 ms loader readings are noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXxg3Spb56Hyu1uXRG5pH4